### PR TITLE
Moved Monocypher `crypto_` symbols out of global namespace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/monocypher"]
 	path = vendor/monocypher
-	url = https://github.com/LoupVaillant/Monocypher.git
+	url = https://github.com/snej/Monocypher.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(MonocypherCppTest)
 add_executable( tests
     src/Monocypher.cc
     src/Monocypher-ed25519.cc
+    src/Monocypher+sha256.cc
+    src/Monocypher+xsalsa20.cc
     test/tests.cc
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,20 +2,26 @@ cmake_minimum_required(VERSION 3.16)
 
 project(MonocypherCppTest)
 
-add_executable(tests
+add_executable( tests
+    src/Monocypher.cc
+    src/Monocypher-ed25519.cc
     test/tests.cc
-    vendor/monocypher/src/monocypher.c
-    vendor/monocypher/src/optional/monocypher-ed25519.c)
+)
 
 include_directories(
     "include"
     "vendor/monocypher/src"
-    "vendor/monocypher/src/optional")
+)
 
-set_property(TARGET tests  PROPERTY CXX_STANDARD 17)
+set_property(TARGET tests  
+    PROPERTY CXX_STANDARD 17
+)
 
 install(TARGETS tests)
 
 enable_testing()
 
-add_test(NAME tests  COMMAND tests)
+add_test(
+    NAME tests
+    COMMAND tests
+)

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This API here is:
 
 **C++:** Requires C++17 or later.
 
-**Header-only:** It consists only of the file `Monocypher.hh`. No extra source files to add to your build (besides the Monocypher C library of course.)
-
 **Idiomatic:**  Cryptographic entities are C++ classes, mostly subclasses of `std::array`. Options like key sizes and algorithms are template parameters. Operations are methods.
+
+**Namespaced:** All symbols are in the C++ namespace `monocypher`. Nothing is defined at global scope, not even the Monocypher C API. This prevents symbol collisions in binaries that also use libSodium or OpenSSL, all of which use the same C `crypto_` prefix as regular Monocypher.
 
 **Safe:** Strong typing makes the API safer. For example, you can't accidentally pass a Diffie-Hellman public key (`monocypher::key_exchange::public_key`) to a function expecting an Ed25519 public key (`monocypher::public_key`).
 Moreover, objects are zeroed out when destructed, to avoid leaving secrets in memory, and the `==` and `!=` operators use constant-time comparisons instead of regular memcmp, to avoid timing attacks.
@@ -27,15 +27,19 @@ Moreover, objects are zeroed out when destructed, to avoid leaving secrets in me
 You should be OK on recent versions of Linux, Windows, and Apple platforms, using up-to-date versions of Clang, GCC or MSVC. That's what the CI tests cover. 
 
 0. If you haven't already, get the Monocypher submodule by running `git submodule update --init`.
-1. Run `run_tests.sh`. This just compiles & runs `test/tests.cc`, some simple tests.
-2. Add the directories `include`, `vendor/monocypher/src` and `vendor/monocypher/src/optional` to your compiler's include path.
-3. Add `vendor/monocypher/src/monocypher.c` and `vendor/monocypher/src/optional/monocypher-ed25519.c` to your project's source file list.
+1. Run the script `run_tests.sh`. This just compiles & runs `test/tests.cc`, some simple tests.
+2. Add the directories `include` and `vendor/monocypher/src` to your compiler's include path.
+3. Add `src/Monocypher.cc` to your project's source file list.
 4. `#include "Monocypher.hh"` in source files where you want to use Monocypher.
+5. If you need to use Ed25519 signatures, also compile `src/Monocypher-ed25519.cc` and `#include "Monocypher-ed25519.hh"`.
 5. Read the [Monocypher documentation](https://monocypher.org/manual/) to learn how to use the API! The correspondence between the functions documented there, and the classes/methods here, should be clear. You can also consult `test/tests.cc` as a source of examples.
+
+> Note that you do _not_ need to compile the Monocypher C source files in `vendor/monocypher/src/`. The C++ source files compile them for you indirectly, wrapping their symbols in a C++ namespace.
 
 ## To-Do
 
 * Higher-level, more C++like API for variable-length data, e.g. messages to be hashed/encrypted. There are many options, like `string`, `string_view`, `istream`, or a pair of begin/end iterators, none of which are entirely compatible with each other and some of which have significant overhead. So I threw up my hand and used good ol' (`const void*, size_t)`. Will the new Range features of C++20 help?
+* iostream adapters for incremental operations.
 * A clean way to get a `byte_array` pointing to crypto data at some address. Currently you can just do e.g. `((public_key*)keyPtr)->check(...)`.
 
 ## Caveats

--- a/include/Monocypher+sha256.hh
+++ b/include/Monocypher+sha256.hh
@@ -1,0 +1,52 @@
+//
+// Monocypher+sha256.hh
+//
+// --- Standard 2-clause BSD licence follows ---
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+#include "Monocypher.hh"
+
+namespace monocypher::ext {
+
+    /// SHA-256 algorithm, for use as the template parameter to `hash`.
+    ///
+    /// @note This functionality is NOT part of Monocypher itself. It's provided for compatibility.
+    /// The implementation is Brad Conte, from <https://github.com/B-Con/crypto-algorithms>
+    struct SHA256 {
+        static constexpr const char* name = "SHA-256";
+        static constexpr size_t hash_size = 256 / 8;
+
+        using context = std::array<uint64_t, 14>;
+
+        static void init_fn  (context *ctx);
+        static void update_fn(context *ctx, const uint8_t *message, size_t  message_size);
+        static void final_fn (context *ctx, uint8_t hash[32]);
+        static void create_fn(uint8_t hash[32], const uint8_t *message, size_t message_size);
+        // (no MAC support, sorry)
+    };
+
+    using sha256 = hash<SHA256>;
+}

--- a/include/Monocypher+xsalsa20.hh
+++ b/include/Monocypher+xsalsa20.hh
@@ -1,0 +1,59 @@
+//
+// Monocypher+xsalsa20.hh
+//
+// --- Standard 2-clause BSD licence follows ---
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+#include "Monocypher.hh"
+
+namespace monocypher::ext {
+
+    /// Alternative algorithm for session::encryption_key --
+    /// XSalsa20 encryption (instead of XChaCha20) and Poly1305 authentication.
+    /// This is compatible with libSodium and NaCl.
+    ///
+    /// @note This functionality is NOT part of Monocypher itself. It's provided for compatibility.
+    /// The implementation is from TweetNaCl, by Daniel J. Bernstein et al.
+    /// <https://tweetnacl.cr.yp.to>
+    struct XSalsa20_Poly1305 {
+        static constexpr const char* name = "XSalsa20+Poly1305";
+
+        static void lock(uint8_t mac[16],
+                         uint8_t *cipher_text,
+                         const uint8_t key[32],
+                         const uint8_t nonce[24],
+                         const uint8_t *plain_text,
+                         size_t text_size);
+        
+        static int unlock(uint8_t *plain_text,
+                          const uint8_t key[32],
+                          const uint8_t nonce[24],
+                          const uint8_t mac[16],
+                          const uint8_t *cipher_text,
+                          size_t text_size);
+    };
+
+}

--- a/include/Monocypher-ed25519.hh
+++ b/include/Monocypher-ed25519.hh
@@ -1,8 +1,30 @@
 //
 // Monocypher-ed25519.hh
 //
-// Copyright © 2022 Jens Alfke. All rights reserved.
+// --- Standard 2-clause BSD licence follows ---
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
 //
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 #include "Monocypher.hh"
@@ -10,10 +32,14 @@
 
 namespace monocypher {
 
+    // This functionality is an extension that comes with Monocypher.
+    // It's not considered part of the core API, but is provided for compatibility.
+
     /// EdDSA with Curve25519 and SHA-512.
-    /// \note This algorithm is more widely used than `EdDSA`, but slower and brings in a bit more code.
+    /// \note This algorithm is more widely used than `EdDSA`, but slower and brings in more code.
     /// (Use as `<Algorithm>` parameter to `signature`, `public_key`, `signing_key`.)
     struct Ed25519 {
+        static constexpr const char* name = "Ed25519";
         static constexpr auto check_fn         = crypto_ed25519_check;
         static constexpr auto sign_fn          = crypto_ed25519_sign;
         static constexpr auto public_key_fn    = crypto_ed25519_public_key;
@@ -27,4 +53,26 @@ namespace monocypher {
         using key_pair    = monocypher::key_pair<Ed25519>;
     };
 
+
+    /// SHA-512 algorithm, for use as the template parameter to `hash`.
+    struct SHA512 {
+        static constexpr const char* name = "SHA-512";
+        static constexpr size_t hash_size = 512 / 8;
+
+        using context = crypto_sha512_ctx;
+        static constexpr auto create_fn = crypto_sha512;
+        static constexpr auto init_fn   = crypto_sha512_init;
+        static constexpr auto update_fn = crypto_sha512_update;
+        static constexpr auto final_fn  = crypto_sha512_final;
+
+        struct mac {
+            using context = crypto_hmac_sha512_ctx;
+            static constexpr auto create_fn = crypto_hmac_sha512;
+            static constexpr auto init_fn   = crypto_hmac_sha512_init;
+            static constexpr auto update_fn = crypto_hmac_sha512_update;
+            static constexpr auto final_fn  = crypto_hmac_sha512_final;
+        };
+    };
+
+    using sha512 = hash<SHA512>;
 }

--- a/include/Monocypher-ed25519.hh
+++ b/include/Monocypher-ed25519.hh
@@ -1,0 +1,27 @@
+//
+// Monocypher-ed25519.hh
+//
+// Copyright © 2022 Jens Alfke. All rights reserved.
+//
+
+#pragma once
+#include "Monocypher.hh"
+#include "../vendor/monocypher/src/optional/monocypher-ed25519.h"
+
+namespace monocypher {
+
+    /// EdDSA with Curve25519 and SHA-512.
+    /// \note This algorithm is more widely used than `EdDSA`, but slower and brings in a bit more code.
+    /// (Use as `<Algorithm>` parameter to `signature`, `public_key`, `signing_key`.)
+    struct Ed25519 {
+        static constexpr auto check_fn      = crypto_ed25519_check;
+        static constexpr auto sign_fn       = crypto_ed25519_sign;
+        static constexpr auto public_key_fn = crypto_ed25519_public_key;
+
+        // Convenient type aliases for those who don't like angle brackets
+        using signature   = monocypher::signature<Ed25519>;
+        using public_key  = monocypher::public_key<Ed25519>;
+        using signing_key = monocypher::signing_key<Ed25519>;
+    };
+
+}

--- a/include/Monocypher-ed25519.hh
+++ b/include/Monocypher-ed25519.hh
@@ -14,14 +14,17 @@ namespace monocypher {
     /// \note This algorithm is more widely used than `EdDSA`, but slower and brings in a bit more code.
     /// (Use as `<Algorithm>` parameter to `signature`, `public_key`, `signing_key`.)
     struct Ed25519 {
-        static constexpr auto check_fn      = crypto_ed25519_check;
-        static constexpr auto sign_fn       = crypto_ed25519_sign;
-        static constexpr auto public_key_fn = crypto_ed25519_public_key;
+        static constexpr auto check_fn         = crypto_ed25519_check;
+        static constexpr auto sign_fn          = crypto_ed25519_sign;
+        static constexpr auto public_key_fn    = crypto_ed25519_public_key;
+        static constexpr auto public_to_kx_fn  = crypto_from_ed25519_public;
+        static constexpr auto private_to_kx_fn = crypto_from_ed25519_private;
 
         // Convenient type aliases for those who don't like angle brackets
         using signature   = monocypher::signature<Ed25519>;
         using public_key  = monocypher::public_key<Ed25519>;
         using signing_key = monocypher::signing_key<Ed25519>;
+        using key_pair    = monocypher::key_pair<Ed25519>;
     };
 
 }

--- a/include/Monocypher.hh
+++ b/include/Monocypher.hh
@@ -39,42 +39,32 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>  // for std::make_unique
+#include <string>
 #include <string_view>
 #include <utility> // for std::pair
 #include <cassert>
-
-// On Apple platforms, `arc4random_buf()` is declared in <cstdlib>, above.
-// On Linux, it _may_ be in <bsd/stdlib.h> if the BSD compatibility lib is present.
-// If it isn't available, we fall back to using C++ `std::random_device` (but see warning below.)
-#ifdef __APPLE__
-#  define MONOCYPHER_HAS_ARC4RANDOM
-#elif defined __has_include
-#  if __has_include (<arc4random.h>)
-#    include <arc4random.h>
-#    define MONOCYPHER_HAS_ARC4RANDOM
-#  elif __has_include (<bsd/stdlib.h>)
-#    include <bsd/stdlib.h>
-#    define MONOCYPHER_HAS_ARC4RANDOM
-#  endif
-#endif
-
-#ifndef MONOCYPHER_HAS_ARC4RANDOM
-#include <random>
-#endif
 
 namespace monocypher {
     using namespace MONOCYPHER_CPP_NAMESPACE;
 
     template <class Algorithm> struct public_key;    // (forward reference)
     template <class Algorithm> struct signing_key;   // (forward reference)
+    template <class Algorithm> struct key_pair;      // (forward reference)
 
 
 //======== Utilities:
 
-    using string_ref = std::string_view;
-
     static inline const uint8_t* u8(const void *p)  {return reinterpret_cast<const uint8_t*>(p);}
     static inline uint8_t* u8(void *p)              {return reinterpret_cast<uint8_t*>(p);}
+
+
+    /// Fills the array with cryptographically-secure random bytes.
+    /// \warning On platforms where `arc4random` is unavailable, this uses `std::random_device`.
+    ///    The C++ standard says "random_device may be implemented in terms of an implementation-
+    ///    defined pseudo-random number engine if a non-deterministic source (e.g. a hardware
+    ///    device) is not available to the implementation." In that situation you should try to use
+    ///    some other source of randomization.
+    void randomize(void *dst, size_t size);
 
 
     /// General-purpose byte array. Used for hashes, nonces, MACs, etc.
@@ -87,24 +77,8 @@ namespace monocypher {
         explicit byte_array(const void *bytes, size_t size)      {fillWith(bytes, size);}
 
         /// Fills the array with cryptographically-secure random bytes.
-        /// \warning On platforms where `arc4random` is unavailable, this uses C++'s `std::random_device`.
-        ///    The C++ standard says "random_device may be implemented in terms of an implementation-defined
-        ///    pseudo-random number engine if a non-deterministic source (e.g. a hardware device) is not
-        ///    available to the implementation." In that situation you should try to use some other source
-        ///    of randomization.
-        void randomize() {
-#ifdef MONOCYPHER_HAS_ARC4RANDOM
-#  undef MONOCYPHER_HAS_ARC4RANDOM
-            ::arc4random_buf(this->data(), Size);
-#else
-            static_assert(Size % sizeof(unsigned) == 0, "randomize() doesn't support this size");
-            std::random_device rng;
-            for (auto i = this->begin(); i != this->end(); i += sizeof(unsigned)) {
-                unsigned r = rng();
-                memcpy(&*i, &r, sizeof(unsigned));
-            }
-#endif
-        }
+        /// \warning See the above warning on the standalone `randomize` function.
+        void randomize()                            {monocypher::randomize(this->data(), Size);}
 
         /// Securely fills the array with zeroes. Unlike a regular `memset` this cannot be optimized
         /// away even if the array is about to be destructed.
@@ -113,7 +87,7 @@ namespace monocypher {
         /// Idiomatic synonym for `wipe`.
         void clear()                                {this->wipe();}
 
-        void fill(uint8_t b) {  // overridden to use `wipe` first
+        void fill(uint8_t b) {  // "overridden" to use `wipe` first
             this->wipe();
             if (b != 0) std::array<uint8_t,Size>::fill(b);  // (wipe already fills with 0)
         }
@@ -121,6 +95,29 @@ namespace monocypher {
         void fillWith(const void *bytes, size_t size) {
             assert(size == sizeof(*this));
             ::memcpy(this->data(), bytes, sizeof(*this));
+        }
+
+        /// Returns a subrange of this array, as a mutable reference.
+        template<size_t Pos, size_t Len>
+        byte_array<Len>& range() {
+            static_assert(Pos + Len <= Size);
+            return reinterpret_cast<byte_array<Len>&>((*this)[Pos]);
+        }
+
+        /// Returns a subrange of this array, as a reference.
+        template<size_t Pos, size_t Len>
+        byte_array<Len> const& range() const {
+            static_assert(Pos + Len <= Size);
+            return reinterpret_cast<byte_array<Len> const&>((*this)[Pos]);
+        }
+
+        /// The `|` operator concatenates two arrays. It's mathematical!
+        template <size_t Size2>
+        byte_array<Size+Size2> operator| (byte_array<Size2> const& other) const {
+            byte_array<Size+Size2> result;
+            result.template range<0,Size>() = *this;
+            result.template range<Size,Size2>() = other;
+            return result;
         }
 
         explicit operator uint8_t*()                         {return this->data();}
@@ -137,6 +134,14 @@ namespace monocypher {
         explicit secret_byte_array(const std::array<uint8_t,Size> &a)   :byte_array<Size>(a) { }
         explicit secret_byte_array(const void *p, size_t s)             :byte_array<Size>(p, s) { }
         ~secret_byte_array()                                            {this->wipe();}
+
+        template <size_t Size2>
+        secret_byte_array<Size+Size2> operator| (byte_array<Size2> const& other) const {
+            secret_byte_array<Size+Size2> result;
+            result.template range<0,Size>() = *this;
+            result.template range<Size,Size2>() = other;
+            return result;
+        }
     };
 
 
@@ -161,6 +166,38 @@ namespace monocypher {
     template<> inline bool operator== (const byte_array<64> &a, const byte_array<64> &b) {
         return 0 == crypto_verify64(a.data(), b.data());
     }
+    //TODO: Implement for other sizes
+
+
+    /// Variable-length data input to a function. Implicit conversion from string and array.
+    struct input_bytes {
+        uint8_t const* const data;
+        size_t const         size;
+
+        input_bytes(const void *d, size_t s)    :data(u8(d)), size(s) { }
+        input_bytes(std::string_view str)       :input_bytes(str.data(), str.size()) { }
+        input_bytes(std::string const& str)     :input_bytes(str.data(), str.size()) { }
+
+        template <size_t Size>
+        input_bytes(byte_array<Size> const& a)  :data(a.data()), size(a.size()) { }
+    };
+
+
+    /// Variable-length mutable data to be returned from a function.
+    struct output_bytes {
+        void*  data;
+        size_t size;
+
+        output_bytes()                          :data(nullptr), size(0) { }
+        output_bytes(void *d, size_t s)         :data(d), size(s) { }
+
+        template <size_t Size>
+        output_bytes(byte_array<Size> &a)       :data(a.data()), size(a.size()) { }
+
+        output_bytes shrunk_to(size_t s) const  {assert(s <= size); return {data, s};}
+
+        explicit operator bool() const          {return data != nullptr;}
+    };
 
 
 //======== General purpose hash (Blake2b)
@@ -169,9 +206,11 @@ namespace monocypher {
     /// Cryptographic hash class, templated by algorithm and size.
     /// The only `Algorithm` currently available is `Blake2b`.
     /// The `Size` is in bytes and must be between 1 and 64. Sizes below 32 are not recommended.
-    template <class HashAlgorithm, size_t Size=64>
-    class hash : public byte_array<Size> {
+    template <class HashAlgorithm>
+    class hash : public byte_array<HashAlgorithm::hash_size> {
     public:
+        static constexpr size_t Size = HashAlgorithm::hash_size;
+
         hash()                                           :byte_array<Size>(0) { }
         explicit hash(const std::array<uint8_t,Size> &a) :byte_array<Size>(a) { }
         hash(const void *data, size_t size)              :byte_array<Size>(data, size) { }
@@ -179,97 +218,121 @@ namespace monocypher {
         /// Returns the Blake2b hash of a message.
         static hash create(const void *message, size_t message_size) noexcept {
             hash result;
-            HashAlgorithm::create_fn(result.data(), Size,
-                                     u8(message), message_size);
+            HashAlgorithm::create_fn(result.data(), u8(message), message_size);
             return result;
         }
 
-        static hash create(string_ref message) noexcept {
-            return create(message.data(), message.size());
+        static hash create(input_bytes message) noexcept {
+            return create(message.data, message.size);
         }
-
 
         /// Returns the hash of a message and a secret key, for use as a MAC.
         template <size_t KeySize>
         static hash createMAC(const void *message, size_t message_size,
-                              const secret_byte_array<KeySize> &key) noexcept {
+                              const byte_array<KeySize> &key) noexcept {
             hash result;
-            HashAlgorithm::create_mac_fn(result, Size,
-                                         key, KeySize,
-                                         u8(message), message_size);
+            HashAlgorithm::mac::create_fn(result.data(),
+                                          key.data(), key.size(),
+                                          u8(message), message_size);
             return result;
         }
 
         template <size_t KeySize>
-        static hash createMAC(string_ref message,
-                              const secret_byte_array<KeySize> &key) noexcept {
-            return createMAC(message.data(), message.size(), key);
+        static hash createMAC(input_bytes message,
+                              const byte_array<KeySize> &key) noexcept {
+            return createMAC(message.data, message.size, key);
         }
 
 
+        template <class BuilderAlg>
+        class _builder {
+        public:
+            /// Hashes more data.
+            _builder& update(const void *message, size_t message_size) {
+                BuilderAlg::update_fn(&_ctx, u8(message), message_size);
+                return *this;
+            }
+
+            _builder& update(input_bytes message) {
+                return update(message.data, message.size);
+            }
+
+            /// Returns the final hash of all the data passed to `update`.
+            [[nodiscard]]
+            hash final() {
+                hash result;
+                BuilderAlg::final_fn(&_ctx, result.data());
+                return result;
+            }
+            
+        protected:
+            typename BuilderAlg::context _ctx;
+        };
+
         /// Incrementally constructs a hash.
-        class builder {
+        class builder : public _builder<HashAlgorithm> {
         public:
             /// Constructs a Blake2b builder.
             /// Call `update` one or more times to hash data, then `final` to get the hash.
             builder() {
-                HashAlgorithm::init_fn(&_ctx, Size);
+                HashAlgorithm::init_fn(&this->_ctx);
             }
+        };
 
+        /// Incrementally constructs a MAC.
+        class mac_builder : public _builder<typename HashAlgorithm::mac> {
+        public:
             /// Constructs a Blake2b builder with a secret key, for creating MACs.
             /// Call `update` one or more times to hash data, then `final` to get the hash.
             template <size_t KeySize>
-            builder(const secret_byte_array<KeySize> &key) {
-                HashAlgorithm::init_mac_fn(&_ctx, Size, key, KeySize);
+            mac_builder(const byte_array<KeySize> &key) {
+                HashAlgorithm::mac::init_fn(&this->_ctx, key.data(), key.size());
             }
-
-            /// Hashes more data.
-            builder& update(const void *message, size_t message_size) {
-                HashAlgorithm::update_fn(&_ctx, u8(message), message_size);
-                return *this;
-            }
-
-            builder& update(string_ref message, size_t message_size) {
-                return update(message.data(), message.size());
-            }
-
-            /// Returns the final Blake2b hash of all the data passed to `update`.
-            [[nodiscard]]
-            hash final() {
-                hash result;
-                HashAlgorithm::final_fn(&_ctx, result.data());
-                return result;
-            }
-
-        private:
-            typename HashAlgorithm::context _ctx;
         };
     };
 
 
     /// Blake2b algorithm; use as `<HashAlgorithm>` in the `hash` template.
+    template <size_t Size>
     struct Blake2b {
+        static constexpr const char* name = "Blake2b";
+        static constexpr size_t hash_size = Size;
+
         using context = crypto_blake2b_ctx;
 
-        static void create_fn(uint8_t *hash, size_t hash_size,
-                              const uint8_t *message, size_t message_size) {
-            crypto_blake2b_general(hash, hash_size, nullptr, 0, message, message_size);
+        static void create_fn(uint8_t *hash, const uint8_t *message, size_t message_size) {
+            crypto_blake2b_general(hash, Size, nullptr, 0, message, message_size);
         }
-        static void init_fn(context *ctx, size_t hash_size) {
-            crypto_blake2b_general_init(ctx, hash_size, nullptr, 0);
+        static void init_fn(context *ctx) {
+            crypto_blake2b_general_init(ctx, Size, nullptr, 0);
         }
-        static constexpr auto create_mac_fn = crypto_blake2b_general;
-        static constexpr auto init_mac_fn   = crypto_blake2b_general_init;
         static constexpr auto update_fn     = crypto_blake2b_update;
         static constexpr auto final_fn      = crypto_blake2b_final;
+
+        struct mac {
+            using context = crypto_blake2b_ctx;
+
+            static void create_fn(uint8_t *hash, const uint8_t *key, size_t key_size,
+                                  const uint8_t *message, size_t message_size)
+            {
+                crypto_blake2b_general(hash, Size, key, key_size, message, message_size);
+            }
+            static void init_fn(context *ctx, const uint8_t *key, size_t key_size) {
+                crypto_blake2b_general_init(ctx, Size, key, key_size);
+            }
+            static constexpr auto update_fn     = crypto_blake2b_update;
+            static constexpr auto final_fn      = crypto_blake2b_final;
+        };
     };
 
 
     /// Blake2b-64 hash class.
-    using blake2b64 = hash<Blake2b,64>;
+    using blake2b64 = hash<Blake2b<64>>;
 
     /// Blake2b-32 hash class.
-    using blake2b32 = hash<Blake2b,32>;
+    using blake2b32 = hash<Blake2b<32>>;
+
+    // Note: See Monocypher-ed25519.hh for SHA-512, and Monocypher+sha256.hh for SHA-256.
 
 
 //======== Password Key Derivation
@@ -315,8 +378,8 @@ namespace monocypher {
             return result;
         }
 
-        static hash create(string_ref password, const salt &s4lt) {
-            return create(password.data(), password.size(), s4lt);
+        static hash create(input_bytes password, const salt &s4lt) {
+            return create(password.data, password.size, s4lt);
         }
 
         /// Generates an Argon2i hash from the input password and a randomly-generated salt value,
@@ -331,8 +394,8 @@ namespace monocypher {
             return {create(password, password_size, s4lt), s4lt};
         }
 
-        static std::pair<hash, salt> create(string_ref password) {
-            return create(password.data(), password.size());
+        static std::pair<hash, salt> create(input_bytes password) {
+            return create(password.data, password.size);
         }
     };
 
@@ -342,6 +405,7 @@ namespace monocypher {
 
     /// Default `Algorithm` template parameter for `key_exchange`.
     struct X25519_HChaCha20 {
+        static constexpr const char* name = "X25519+HChaCha20";
         static constexpr auto get_public_key_fn = crypto_key_exchange_public_key;
         static constexpr auto key_exchange_fn   = crypto_key_exchange;
     };
@@ -350,6 +414,7 @@ namespace monocypher {
     /// you're doing!
     /// @warning Shared secrets are not quite random. Hash them to derive an actual shared key.
     struct X25519_Raw {
+        static constexpr const char* name = "X25519";
         static constexpr auto get_public_key_fn = crypto_x25519_public_key;
         static constexpr auto key_exchange_fn   = crypto_x25519;
     };
@@ -401,6 +466,11 @@ namespace monocypher {
         template <class SigningAlgorithm>
         explicit key_exchange(const signing_key<SigningAlgorithm>&);
 
+        template <class SigningAlgorithm>
+        explicit key_exchange(const key_pair<SigningAlgorithm>& kp)
+        :key_exchange(kp.get_signing_key())
+        { }
+
         /// Returns the public key to send to the other party.
         public_key get_public_key() const {
             public_key pubkey;
@@ -427,6 +497,7 @@ namespace monocypher {
 
 //======== Authenticated Encryption
 
+    struct XChaCha20_Poly1305;
 
     namespace session {
 
@@ -463,11 +534,12 @@ namespace monocypher {
 
         /// A session key for _symmetric_ encryption/decryption -- both sides must use the same key.
         /// Consider using the shared secret produced by `key_exchange` as the key.
-        struct key : public secret_byte_array<32> {
-            key()                                           {randomize();}
-            explicit key(const std::array<uint8_t,32> &a)   :secret_byte_array<32>(a) { }
-            key(const void *data, size_t size)              :secret_byte_array<32>(data, size) { }
-            explicit key(string_ref k3y)                    :key(k3y.data(), k3y.size()) { }
+        template <typename Algorithm = XChaCha20_Poly1305>
+        struct encryption_key : public secret_byte_array<32> {
+            encryption_key()                                           {randomize();}
+            explicit encryption_key(const std::array<uint8_t,32> &a)   :secret_byte_array<32>(a) { }
+            encryption_key(const void *data, size_t size)              :secret_byte_array<32>(data, size) { }
+            explicit encryption_key(input_bytes k3y)                   :encryption_key(k3y.data, k3y.size) { }
 
             /// Encrypts `plain_text`, writing the result to `cipher_text` and producing a `mac`.
             /// The MAC _must_ be sent along with the ciphertext.
@@ -487,16 +559,16 @@ namespace monocypher {
                      const void *plain_text, size_t text_size,
                      void *cipher_text) const {
                 mac out_mac;
-                crypto_lock(out_mac.data(), u8(cipher_text), this->data(), nonce.data(),
-                              u8(plain_text), text_size);
+                Algorithm::lock(out_mac.data(), u8(cipher_text), this->data(), nonce.data(),
+                                u8(plain_text), text_size);
                 return out_mac;
             }
 
             [[nodiscard]]
             mac lock(const nonce &nonce,
-                     string_ref plain_text,
+                     input_bytes plain_text,
                      void *cipher_text) const {
-                return lock(nonce, plain_text.data(), plain_text.size(), cipher_text);
+                return lock(nonce, plain_text.data, plain_text.size, cipher_text);
             }
 
             /// Authenticates `cipher_text` using the `mac`, then decrypts it, writing the result to
@@ -513,27 +585,101 @@ namespace monocypher {
                         const mac &mac,
                         const void *cipher_text, size_t text_size,
                         void *plain_text) const {
-                return 0 == crypto_unlock(u8(plain_text), this->data(), nonce.data(),
-                                          mac.data(), u8(cipher_text), text_size);
+                return 0 == Algorithm::unlock(u8(plain_text), this->data(), nonce.data(),
+                                              mac.data(), u8(cipher_text), text_size);
             }
 
             [[nodiscard]]
             bool unlock(const nonce &nonce,
                         const mac &mac,
-                        string_ref cipher_text,
+                        input_bytes cipher_text,
                         void *plain_text) const {
-                return unlock(nonce, mac, cipher_text.data(), cipher_text.size(), plain_text);
+                return unlock(nonce, mac, cipher_text.data, cipher_text.size, plain_text);
             }
+
+
+            /// Encrypts `plain_text`, writing the MAC and ciphertext to `output_buffer`.
+            /// Returns `output_buffer` resized to the actual output size, which is
+            /// `sizeof(mac) + plain_text.size`.
+            /// \note  This function is compatible with libSodium's `crypto_box_easy`.
+            output_bytes box(const nonce &nonce,
+                             input_bytes plain_text,
+                             output_bytes output_buffer) const
+            {
+                output_buffer = output_buffer.shrunk_to(sizeof(mac) + plain_text.size);
+                auto mac_p = (mac*)output_buffer.data;
+                *mac_p = lock(nonce, plain_text, mac_p + 1);
+                return output_buffer;
+            }
+
+            /// A version of `box` that returns the output as a `byte_array`.
+            /// The array **must** be the exact size of the output.
+            template <size_t OutputSize>
+            byte_array<OutputSize> box(const nonce &nonce,
+                                       input_bytes plain_text) const
+            {
+                assert(OutputSize == sizeof(mac) + plain_text.size);
+                byte_array<OutputSize> result;
+                box(nonce, plain_text, result);
+                return result;
+            }
+
+            /// Decrypts a MAC-and-ciphertext produced by `box`, into `output_buffer`.
+            /// Returns `output_buffer` resized to the actual output size, which is
+            /// `boxed_cipher_text.size - sizeof(mac)`, or {NULL,0} if the ciphertext is invalid.
+            /// \note  This function is compatible with libSodium's `crypto_unbox_easy`.
+            [[nodiscard]]
+            output_bytes unbox(const nonce &nonce,
+                               input_bytes boxed_cipher_text,
+                               output_bytes output_buffer) const
+            {
+                if (boxed_cipher_text.size < sizeof(mac))
+                    return {};
+                output_buffer = output_buffer.shrunk_to(boxed_cipher_text.size - sizeof(mac));
+                auto mac_p = (const mac*)boxed_cipher_text.data;
+                if (!unlock(nonce, *mac_p, mac_p + 1,
+                            output_buffer.size,
+                            output_buffer.data))
+                    return {};
+                return output_buffer;
+            }
+
+            /// A version of `unbox` that returns the output as a `byte_array`.
+            template <size_t OutputSize>
+            bool unbox(const nonce &nonce,
+                       input_bytes boxed_cipher_text,
+                       byte_array<OutputSize> &output) const
+            {
+                output_bytes out = unbox(nonce, boxed_cipher_text, {output.data(), output.size()});
+                return out.size == output.size();
+            }
+
         };
 
+        using key = encryption_key<XChaCha20_Poly1305>;
+
     } // end 'session'
+
+
+    /// Default algorithm for `session::encryption_key` --
+    /// XChaCha20 encryption and Poly1305 authentication.
+    /// @note  This is not compatible with libSodium or NaCl, which use the XSalsa20 cipher.
+    ///        But see `XSalsa20_Poly1305`, in `Monocypher+xsalsa20.hh`.
+    struct XChaCha20_Poly1305 {
+        static constexpr const char* name = "XChaCha20+Poly1305";
+        static constexpr auto lock   = crypto_lock;
+        static constexpr auto unlock = crypto_unlock;
+    };
 
 
 //======== Signatures
 
 
+    struct EdDSA;
+
+
     /// A digital signature. (For <Algorithm> use <EdDSA> or <Ed25519>.)
-    template <class Algorithm>
+    template <class Algorithm = EdDSA>
     struct signature : public byte_array<64> {
         signature()                                           :byte_array<64>(0) { }
         explicit signature(const std::array<uint8_t,64> &a)   :byte_array<64>(a) { }
@@ -542,12 +688,12 @@ namespace monocypher {
 
 
     /// A public key for verifying signatures. (For <Algorithm> use <EdDSA> or <Ed25519>.)
-    template <class Algorithm>
+    template <class Algorithm = EdDSA>
     struct public_key : public byte_array<32> {
         public_key()                                           :byte_array<32>(0) { }
         explicit public_key(const std::array<uint8_t,32> &a)   :byte_array<32>(a) { }
         public_key(const void *data, size_t size)              :byte_array<32>(data, size) { }
-        explicit public_key(string_ref k)                      :public_key(k.data(), k.size()) { }
+        explicit public_key(input_bytes k)                      :public_key(k.data, k.size) { }
 
         /// Verifies a signature.
         [[nodiscard]]
@@ -556,8 +702,8 @@ namespace monocypher {
         }
 
         [[nodiscard]]
-        bool check(const signature<Algorithm> &sig, string_ref msg) const {
-            return check(sig, msg.data(), msg.size());
+        bool check(const signature<Algorithm> &sig, input_bytes msg) const {
+            return check(sig, msg.data, msg.size);
         }
 
         /// Converts a public signature-verification key to a Curve25519 public key,
@@ -575,14 +721,13 @@ namespace monocypher {
 
 
     /// A secret/private key for generating signatures. (For <Algorithm> use <EdDSA> or <Ed25519>.)
-    template <class Algorithm>
+    template <class Algorithm = EdDSA>
     struct signing_key : public secret_byte_array<32> {
         using public_key = monocypher::public_key<Algorithm>;
         using signature = monocypher::signature<Algorithm>;
 
         explicit signing_key(const std::array<uint8_t,32> &a) :secret_byte_array<32>(a) { }
         signing_key(const void *data, size_t size)            :secret_byte_array<32>(data, size) { }
-        explicit signing_key(string_ref k)                    :signing_key(k.data(), k.size()) { }
 
         /// Creates a random secret key.
         static signing_key generate() {
@@ -607,8 +752,8 @@ namespace monocypher {
 
         /// Signs a message. (Passing in the public key speeds up the computation.)
         [[nodiscard]]
-        signature sign(string_ref message, const public_key &pubKey) const {
-            return sign(message.data(), message.size(), pubKey);
+        signature sign(input_bytes message, const public_key &pubKey) const {
+            return sign(message.data, message.size, pubKey);
         }
 
         /// Signs a message.
@@ -623,8 +768,8 @@ namespace monocypher {
         /// Signs a message.
         /// @note This has to first recompute the public key, which makes it a bit slower.
         [[nodiscard]]
-        signature sign(string_ref message) const {
-            return sign(message.data(), message.size());
+        signature sign(input_bytes message) const {
+            return sign(message.data, message.size);
         }
 
     private:
@@ -634,7 +779,7 @@ namespace monocypher {
 
     /// A `signing_key` together with its `public_key`.
     /// Takes up more space, but is faster because the public key doesn't have to be derived.
-    template <class Algorithm>
+    template <class Algorithm = EdDSA>
     struct key_pair {
         using signing_key = monocypher::signing_key<Algorithm>;
         using public_key = monocypher::public_key<Algorithm>;
@@ -650,7 +795,6 @@ namespace monocypher {
         explicit key_pair(const signing_key &sk)            :key_pair(sk, sk.get_public_key()) { }
         explicit key_pair(const std::array<uint8_t,32> &sa) :key_pair(signing_key(sa)) { }
         key_pair(const void *sk_data, size_t size)          :key_pair(signing_key(sk_data, size)) { }
-        explicit key_pair(string_ref sk_data)               :key_pair(signing_key(sk_data)) { }
 
         /// Returns the signing key.
         const signing_key& get_signing_key() const          {return _signingKey;}
@@ -661,12 +805,23 @@ namespace monocypher {
         /// Signs a message.
         [[nodiscard]]
         signature sign(const void *message, size_t message_size) const {
-            return signing_key::sign(message, message_size, _publicKey);
+            return _signingKey.sign(message, message_size, _publicKey);
         }
 
         /// Signs a message.
         [[nodiscard]]
-        signature sign(string_ref msg) const                  {return sign(msg.data(), msg.size());}
+        signature sign(input_bytes msg) const               {return sign(msg.data, msg.size);}
+
+        /// Verifies a signature.
+        [[nodiscard]]
+        bool check(const signature &sig, const void *msg, size_t msg_size) const {
+            return _publicKey.check(sig, msg, msg_size);
+        }
+
+        [[nodiscard]]
+        bool check(const signature &sig, input_bytes msg) const {
+            return check(sig, msg.data, msg.size);
+        }
 
     private:
         signing_key _signingKey;
@@ -679,6 +834,7 @@ namespace monocypher {
     /// \note  This is not the same as the commonly-used Ed25519, which uses SHA-512.
     ///        An `Ed25519` struct is declared in `Monocypher-ed25519.hh`.
     struct EdDSA {
+        static constexpr const char* name      = "EdDSA";
         static constexpr auto check_fn         = crypto_check;
         static constexpr auto sign_fn          = crypto_sign;
         static constexpr auto public_key_fn    = crypto_sign_public_key;

--- a/src/Monocypher+sha256.cc
+++ b/src/Monocypher+sha256.cc
@@ -1,0 +1,65 @@
+//
+// Monocypher+sha256.cc
+//
+// Copyright © 2022 Jens Alfke. All rights reserved.
+//
+// --- Standard 2-clause BSD licence follows ---
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Monocypher+sha256.hh"
+
+// Wrap 3rd party sha256.c in a namespace to avoid messing with global namespace:
+namespace monocypher::b_con {
+#include "../vendor/B-Con/sha256.c"
+}
+
+namespace monocypher::ext {
+    using namespace monocypher::b_con;
+
+    // Make sure my `context` type can serve as a `SHA256_CTX` for the implementation:
+    static_assert(sizeof(SHA256::context)  == sizeof(SHA256_CTX));
+    static_assert(alignof(SHA256::context) == alignof(SHA256_CTX));
+
+    void SHA256::create_fn(uint8_t hash[32], const uint8_t *message, size_t message_size) {
+        context ctx;
+        init_fn(&ctx);
+        update_fn(&ctx, message, message_size);
+        final_fn(&ctx, hash);
+    }
+
+    void SHA256::init_fn(context *ctx) {
+        sha256_init((SHA256_CTX*)ctx);
+    }
+
+    void SHA256::update_fn(context *ctx, const uint8_t *message, size_t  message_size) {
+        sha256_update((SHA256_CTX*)ctx, message, message_size);
+    }
+
+    void SHA256::final_fn(context *ctx, uint8_t hash[32]) {
+        sha256_final((SHA256_CTX*)ctx, hash);
+    }
+
+
+}

--- a/src/Monocypher+xsalsa20.cc
+++ b/src/Monocypher+xsalsa20.cc
@@ -1,0 +1,103 @@
+//
+// Monocypher+xsalsa20.cc
+//
+// Copyright © 2022 Jens Alfke. All rights reserved.
+//
+// --- Standard 2-clause BSD licence follows ---
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "Monocypher+xsalsa20.hh"
+#include <memory>
+#include <string.h>
+
+// Wrap 3rd party tweetnacl.c in a namespace to avoid messing with global namespace:
+namespace monocypher::tweetnacl {
+    #include "../vendor/tweetnacl/tweetnacl.c"
+
+    // tweetnacl leaves this undefined. The code below doesn't require it, but in a debug build
+    // without dead-stripping, we get link errors without it.
+    void randombytes(uint8_t *bytes, unsigned long long size) {
+        monocypher::randomize(bytes, size_t(size));
+    }
+}
+
+
+namespace monocypher::ext {
+    using namespace monocypher::tweetnacl;
+
+    // NaCL's `secretbox` C API is batshit crazy:  https://nacl.cr.yp.to/secretbox.html 🤯
+    // It requires 32 zero bytes before the plaintext,
+    // and writes 16 zero bytes before the mac-and-ciphertext.
+    // The size parameter needs to include those 32 bytes.
+    // Unboxing is the reverse.
+    // WTF.
+
+    void XSalsa20_Poly1305::lock(uint8_t mac[16], uint8_t *out,
+                                 const uint8_t key[32], const uint8_t nonce[24],
+                                 const uint8_t *plaintext, size_t size)
+    {
+        //TODO: Find a way to do this without having to allocate temporary buffers.
+        auto inBuffer = std::make_unique<uint8_t[]>(32 + size);
+        memset(&inBuffer[ 0], 0, 32);
+        memcpy(&inBuffer[32], plaintext, size);
+
+        auto outBuffer = std::make_unique<uint8_t[]>(32 + size);
+
+        crypto_secretbox_xsalsa20poly1305_tweet(outBuffer.get(),
+                                                inBuffer.get(),
+                                                size + 32,
+                                                nonce, key);
+
+        memcpy(mac, &outBuffer[16], 16);
+        memcpy(out, &outBuffer[32], size);
+
+//      Self-test:
+//        assert(0 == unlock(&inBuffer[0], key, nonce, mac, out, size)
+//               && 0 == memcmp(plaintext, &inBuffer[0], size));
+        crypto_wipe(&inBuffer[32], size);
+    }
+
+    int XSalsa20_Poly1305::unlock(uint8_t *out,
+                                  const uint8_t key[32], const uint8_t nonce[24],
+                                  const uint8_t mac[16],
+                                  const uint8_t *ciphertext, size_t size)
+    {
+        //TODO: Find a way to do this without having to allocate temporary buffers.
+        auto inBuffer = std::make_unique<uint8_t[]>(32 + size);
+        memset(&inBuffer[0], 0, 16);
+        memcpy(&inBuffer[16], mac, 16);
+        memcpy(&inBuffer[32], ciphertext, size);
+
+        auto outBuffer = std::make_unique<uint8_t[]>(32 + size);
+
+        if (0 != crypto_secretbox_xsalsa20poly1305_tweet_open(outBuffer.get(),
+                                                              inBuffer.get(), size + 32,
+                                                              nonce, key))
+            return -1;
+        memcpy(out, &outBuffer[32], size);
+        crypto_wipe(&outBuffer[32], size);
+        return 0;
+    }
+}

--- a/src/Monocypher-ed25519.cc
+++ b/src/Monocypher-ed25519.cc
@@ -1,0 +1,6 @@
+//
+// Monocypher-ed25519.cc
+//
+
+#include "Monocypher-ed25519.hh"
+#include "../vendor/monocypher/src/optional/monocypher-ed25519.c"

--- a/src/Monocypher-ed25519.cc
+++ b/src/Monocypher-ed25519.cc
@@ -3,4 +3,6 @@
 //
 
 #include "Monocypher-ed25519.hh"
+
+// Bring in the monocypher implementation, still wrapped in a C++namespace:
 #include "../vendor/monocypher/src/optional/monocypher-ed25519.c"

--- a/src/Monocypher.cc
+++ b/src/Monocypher.cc
@@ -1,0 +1,6 @@
+//
+// Monocypher.cc
+//
+
+#include "Monocypher.hh"
+#include "../vendor/monocypher/src/monocypher.c"

--- a/src/Monocypher.cc
+++ b/src/Monocypher.cc
@@ -3,4 +3,46 @@
 //
 
 #include "Monocypher.hh"
+
+// Bring in the monocypher implementation, still wrapped in a C++namespace:
 #include "../vendor/monocypher/src/monocypher.c"
+
+
+// On Apple platforms, `arc4random_buf()` is declared in <stdlib.h>.
+// On Linux, it _may_ be in <bsd/stdlib.h> if the BSD compatibility lib is present.
+// If it isn't available, we fall back to using C++ `std::random_device` (but see warning below.)
+#ifdef __APPLE__
+#  define MONOCYPHER_HAS_ARC4RANDOM
+#elif defined __has_include
+#  if __has_include (<arc4random.h>)
+#    include <arc4random.h>
+#    define MONOCYPHER_HAS_ARC4RANDOM
+#  elif __has_include (<bsd/stdlib.h>)
+#    include <bsd/stdlib.h>
+#    define MONOCYPHER_HAS_ARC4RANDOM
+#  endif
+#endif
+
+#ifndef MONOCYPHER_HAS_ARC4RANDOM
+#include <random>
+#endif
+
+
+namespace monocypher {
+
+    void randomize(void *dst, size_t size) {
+#ifdef MONOCYPHER_HAS_ARC4RANDOM
+#  undef MONOCYPHER_HAS_ARC4RANDOM
+        ::arc4random_buf(dst, size);
+#else
+        assert(size % sizeof(unsigned) == 0);   // TODO: Handle odd sizes
+        std::random_device rng;
+        auto start = (uint8_t*)dst, end = start + size;
+        for (uint8_t *i = start; i != end; i += sizeof(unsigned)) {
+            unsigned r = rng();
+            memcpy(i, &r, sizeof(unsigned));
+        }
+#endif
+    }
+
+}

--- a/test/tests.cc
+++ b/test/tests.cc
@@ -6,6 +6,8 @@
 //
 
 #include "tests.hh"
+#include "Monocypher+sha256.hh"
+#include "Monocypher+xsalsa20.hh"
 #include <iostream>
 #include <tuple>    // for `tie`
 
@@ -25,7 +27,7 @@ static void test_randomize() {
     for (size_t i = 0; i < sizeof(key); ++i)
         assert(key[i] == 0);
 
-    // Randomize 'key', then heck that all bytes have changed (from 00.)
+    // Randomize 'key', then check that all bytes have changed (from 00.)
     // Obviously this can fail even with a real RNG, so try multiple times.
     // (Chance of one failure is 12%; ten in a row is less than one in a billion.)
     bool changed = false;
@@ -48,24 +50,107 @@ static void test_randomize() {
 }
 
 
+template <size_t Size>
 static void test_blake2b() {
-    cout << "--- test_blake2b ---\n";
-    monocypher::hash<Blake2b> h1 = blake2b64::create("hello world", 11);
+    using blake2b = monocypher::hash<Blake2b<Size>>;
+    constexpr const char* kExpected =
+        (Size == 32) ? "256C83B2 97114D20 1B30179F 3F0EF0CA CE978362 2DA59743 26B43617 8AEEF610"
+                     : "021CED87 99296CEC A557832A B941A50B 4A11F834 78CF141F 51F933F6 53AB9FBC "
+                       "C05A037C DDBED06E 309BF334 942C4E58 CDF1A46E 237911CC D7FCF978 7CBC7FD0";
+
+    cout << "--- test_blake2b_" << Size << " ---\n";
+    blake2b h1 = blake2b::create("hello world"sv);
     string str1 = hexString(h1);
     cout << str1 << "\n";
-    assert(str1 == "021CED87 99296CEC A557832A B941A50B 4A11F834 78CF141F 51F933F6 53AB9FBC "
-                   "C05A037C DDBED06E 309BF334 942C4E58 CDF1A46E 237911CC D7FCF978 7CBC7FD0");
+    assert(str1 == kExpected);
 
-    blake2b64::builder b;
-    b.update("hello", 5).update(" ", 1).update("world", 5);
-    blake2b64 h2 = b.final();
+    typename blake2b::builder b;
+    b.update("hello"sv).update(" "sv).update("world"sv);
+    blake2b h2 = b.final();
 
     string str2 = hexString(h2);
     cout << str2 << "\n";
     assert(str2 == str1);
-
     assert(h2 == h1);
+
+    // HMAC:
+    constexpr const char* kExpectedMAC =
+        (Size == 32) ? "E3EEFDF5 A34BD04B 40813366 D1609E50 43E7326B 3058DB9C 3C0C9AB0 253311C2"
+                     : "03323A49 AFDF08AA 4D4AEA87 E610BCB1 FEC593AE E11C9CC0 1C2B2474 9FF5A0C4 "
+                       "3D050C23 F8E325FB 8A8185AC 0B82C7E8 078E0D00 2907FF62 65D735AB 8F1A9CE2";
+
+    secret_byte_array<32> key;
+    key.wipe();
+    key[7] = 123;
+    blake2b mac = blake2b::createMAC("hello world"sv, key);
+    cout << "HMAC = " << hexString(mac) << endl;
+    assert(hexString(mac) == kExpectedMAC);
+
+    typename blake2b::mac_builder hm(key);
+    hm.update("hello"sv).update(" "sv).update("world"sv);
+    blake2b mac2 = hm.final();
+    cout << "HMAC = " << hexString(mac2) << endl;
+    assert(mac2 == mac);
+
     cout << "✔︎ Blake2b passed\n\n";
+}
+
+
+static void test_sha256() {
+    cout << "--- test_sha256 ---\n";
+    auto h1 = ext::sha256::create("hello world", 11);
+    string str1 = hexString(h1);
+    cout << str1 << "\n";
+    assert(str1 == "B94D27B9 934D3E08 A52E52D7 DA7DABFA C484EFE3 7A5380EE 9088F7AC E2EFCDE9");
+
+    ext::sha256::builder b;
+    b.update("hello"sv).update(" "sv).update("world"sv);
+    ext::sha256 h2 = b.final();
+
+    string str2 = hexString(h2);
+    cout << str2 << "\n";
+    assert(str2 == str1);
+    assert(h2 == h1);
+
+    // (No HMAC support in SHA-256 yet)
+
+    cout << "✔︎ SHA256 passed\n\n";
+}
+
+
+static void test_sha512() {
+    cout << "--- test_sha512 ---\n";
+    auto h1 = sha512::create("hello world", 11);
+    string str1 = hexString(h1);
+    cout << str1 << "\n";
+    assert(str1 == "309ECC48 9C12D6EB 4CC40F50 C902F2B4 D0ED77EE 511A7C7A 9BCD3CA8 6D4CD86F "
+                   "989DD35B C5FF4996 70DA3425 5B45B0CF D830E81F 605DCF7D C5542E93 AE9CD76F");
+
+    sha512::builder b;
+    b.update("hello"sv).update(" "sv).update("world"sv);
+    sha512 h2 = b.final();
+
+    string str2 = hexString(h2);
+    cout << str2 << "\n";
+    assert(str2 == str1);
+    assert(h2 == h1);
+
+    // HMAC:
+    secret_byte_array<64> key;
+    key.wipe();
+    key[7] = 123;
+    sha512 mac = sha512::createMAC("hello world"sv, key);
+    cout << "HMAC = " << hexString(mac) << endl;
+    assert(hexString(mac) == "2FEDCA75 30B41289 556CFC3B E1D7014E E8468430 0B5B0FF2 845AE074 "
+           "424C2DC6 538A3BB7 B2B33174 13CDA55D 0FD0D54C 29651E7C 2168E82D F72B5C89 9447BD7A");
+
+    sha512::mac_builder hm(key);
+    hm.update("hello"sv).update(" "sv).update("world"sv);
+    sha512 mac2 = hm.final();
+    cout << "HMAC = " << hexString(mac2) << endl;
+    assert(mac2 == mac);
+
+    cout << "✔︎ SHA512 passed\n\n";
 }
 
 
@@ -138,11 +223,12 @@ static void test_key_exchange_raw() {
 }
 
 
+template <class Algorithm>
 static void test_encryption() {
-    cout << "--- test_encryption ---\n";
+    cout << "--- test_encryption<" << Algorithm::name << "> ---\n";
     const string message = "ATTACK AT DAWN";
 
-    session::key key;       // random key
+    session::encryption_key<Algorithm> key;       // random key
     session::nonce nonce;   // random nonce
     char ciphertext[14];
     assert(sizeof(ciphertext) == message.size());
@@ -157,9 +243,12 @@ static void test_encryption() {
     string plaintextStr(plaintext, sizeof(plaintext));
     cout << "unlocked: '" << plaintextStr << "'\n";
     assert(plaintextStr == message);
+}
 
+
+static void test_nonce() {
     // Test integer nonce:
-    nonce = 0x12345678FF;
+    session::nonce nonce(0x12345678FF);
     auto nonceStr = hexString(nonce);
     cout << "Integer Nonce = " << nonceStr << "\n";
     assert(nonceStr == "FF785634 12000000 00000000 00000000 00000000 00000000");
@@ -172,11 +261,12 @@ static void test_encryption() {
 }
 
 
+template <class Algorithm>
 static void test_signatures() {
     static const char *message = "THIS IS FINE. I'M OKAY WITH THE EVENTS THAT ARE UNFOLDING"
                                  " CURRENTLY. THAT'S OKAY, THINGS ARE GOING TO BE OKAY.";
-    cout << "--- test_signatures ---\n";
-    auto key = EdDSA::signing_key::generate();
+    cout << "--- test_signatures<" << Algorithm::name << "> ---\n";
+    auto key = signing_key<Algorithm>::generate();
     cout << "secret key: " << hexString(key) << "\n";
     auto pubKey = key.get_public_key();
     cout << "public key: " << hexString(pubKey) << "\n";
@@ -195,10 +285,11 @@ static void test_signatures() {
 }
 
 
+template <class Algorithm>
 static void test_signatures_to_kx() {
-    cout << "--- test_signatures_to_kx ---\n";
-    auto keyPair1 = EdDSA::key_pair::generate();
-    auto keyPair2 = EdDSA::key_pair::generate();
+    cout << "--- test_signatures_to_kx<" << Algorithm::name << "> ---\n";
+    auto keyPair1 = key_pair<Algorithm>::generate();
+    auto keyPair2 = key_pair<Algorithm>::generate();
 
     // Convert the signing key-pairs to key-exchange key-pairs:
     key_exchange kx1(keyPair1.get_signing_key());
@@ -226,13 +317,24 @@ static void test_signatures_to_kx() {
 int main(int argc, const char * argv[]) {
     cout << "Testing Monocypher-C++ wrapper...\n\n";
     test_randomize();
-    test_blake2b();
+    test_blake2b<32>();
+    test_blake2b<64>();
+    test_sha512();
     test_argon2i();
     test_key_exchange();
     test_key_exchange_raw();
-    test_encryption();
-    test_signatures();
-    test_signatures_to_kx();
+    test_encryption<XChaCha20_Poly1305>();
+    test_nonce();
+    test_signatures<EdDSA>();
+    test_signatures<Ed25519>();
+    test_signatures_to_kx<EdDSA>();
+    test_signatures_to_kx<Ed25519>();
+    cout << "✔︎✔︎ CORE C++ WRAPPER TESTS PASSED ✔︎✔︎\n";
+
+    cout << "Now testing extensions ...\n\n";
+    test_sha256();
+    test_encryption<ext::XSalsa20_Poly1305>();
+
     cout << "✔︎✔︎✔︎ ALL C++ WRAPPER TESTS PASSED ✔︎✔︎✔︎ (but this is not a full test of Monocypher itself)\n";
     return 0;
 }

--- a/test/tests.hh
+++ b/test/tests.hh
@@ -7,6 +7,7 @@
 
 #pragma once
 #include "Monocypher.hh"
+#include "Monocypher-ed25519.hh"
 #include <cstdio>
 #include <string>
 

--- a/vendor/B-Con/sha256.c
+++ b/vendor/B-Con/sha256.c
@@ -1,0 +1,172 @@
+//
+//  sha256.c
+//  Monocypher-cpp
+//
+//  Imported by Jens Alfke on 2/9/22.
+//  Source: <https://github.com/B-Con/crypto-algorithms/blob/master/sha256.c>
+//  Changes:
+//      - Declare `sha256_transform` as `static`
+//  License:
+//      From the README.md:
+//      >This code is released into the public domain free of any restrictions. The author requests
+//      >acknowledgement if the code is used, but does not require it. This code is provided free of
+//      >any liability and without any quality claims by the author.
+
+/*********************************************************************
+* Filename:   sha256.c
+* Author:     Brad Conte (brad AT bradconte.com)
+* Copyright:
+* Disclaimer: This code is presented "as is" without any guarantees.
+* Details:    Implementation of the SHA-256 hashing algorithm.
+              SHA-256 is one of the three algorithms in the SHA2
+              specification. The others, SHA-384 and SHA-512, are not
+              offered in this implementation.
+              Algorithm specification can be found here:
+               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
+              This implementation uses little endian byte order.
+*********************************************************************/
+
+/*************************** HEADER FILES ***************************/
+#include <stdlib.h>
+#include <memory.h>
+#include "sha256.h"
+
+/****************************** MACROS ******************************/
+#define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
+#define ROTRIGHT(a,b) (((a) >> (b)) | ((a) << (32-(b))))
+
+#define CH(x,y,z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x,y,z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTRIGHT(x,2) ^ ROTRIGHT(x,13) ^ ROTRIGHT(x,22))
+#define EP1(x) (ROTRIGHT(x,6) ^ ROTRIGHT(x,11) ^ ROTRIGHT(x,25))
+#define SIG0(x) (ROTRIGHT(x,7) ^ ROTRIGHT(x,18) ^ ((x) >> 3))
+#define SIG1(x) (ROTRIGHT(x,17) ^ ROTRIGHT(x,19) ^ ((x) >> 10))
+
+/**************************** VARIABLES *****************************/
+static const WORD k[64] = {
+	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
+/*********************** FUNCTION DEFINITIONS ***********************/
+static void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
+{
+	WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
+
+	for (i = 0, j = 0; i < 16; ++i, j += 4)
+		m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+	for ( ; i < 64; ++i)
+		m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+
+	a = ctx->state[0];
+	b = ctx->state[1];
+	c = ctx->state[2];
+	d = ctx->state[3];
+	e = ctx->state[4];
+	f = ctx->state[5];
+	g = ctx->state[6];
+	h = ctx->state[7];
+
+	for (i = 0; i < 64; ++i) {
+		t1 = h + EP1(e) + CH(e,f,g) + k[i] + m[i];
+		t2 = EP0(a) + MAJ(a,b,c);
+		h = g;
+		g = f;
+		f = e;
+		e = d + t1;
+		d = c;
+		c = b;
+		b = a;
+		a = t1 + t2;
+	}
+
+	ctx->state[0] += a;
+	ctx->state[1] += b;
+	ctx->state[2] += c;
+	ctx->state[3] += d;
+	ctx->state[4] += e;
+	ctx->state[5] += f;
+	ctx->state[6] += g;
+	ctx->state[7] += h;
+}
+
+void sha256_init(SHA256_CTX *ctx)
+{
+	ctx->datalen = 0;
+	ctx->bitlen = 0;
+	ctx->state[0] = 0x6a09e667;
+	ctx->state[1] = 0xbb67ae85;
+	ctx->state[2] = 0x3c6ef372;
+	ctx->state[3] = 0xa54ff53a;
+	ctx->state[4] = 0x510e527f;
+	ctx->state[5] = 0x9b05688c;
+	ctx->state[6] = 0x1f83d9ab;
+	ctx->state[7] = 0x5be0cd19;
+}
+
+void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len)
+{
+	WORD i;
+
+	for (i = 0; i < len; ++i) {
+		ctx->data[ctx->datalen] = data[i];
+		ctx->datalen++;
+		if (ctx->datalen == 64) {
+			sha256_transform(ctx, ctx->data);
+			ctx->bitlen += 512;
+			ctx->datalen = 0;
+		}
+	}
+}
+
+void sha256_final(SHA256_CTX *ctx, BYTE hash[])
+{
+	WORD i;
+
+	i = ctx->datalen;
+
+	// Pad whatever data is left in the buffer.
+	if (ctx->datalen < 56) {
+		ctx->data[i++] = 0x80;
+		while (i < 56)
+			ctx->data[i++] = 0x00;
+	}
+	else {
+		ctx->data[i++] = 0x80;
+		while (i < 64)
+			ctx->data[i++] = 0x00;
+		sha256_transform(ctx, ctx->data);
+		memset(ctx->data, 0, 56);
+	}
+
+	// Append to the padding the total message's length in bits and transform.
+	ctx->bitlen += ctx->datalen * 8;
+	ctx->data[63] = ctx->bitlen;
+	ctx->data[62] = ctx->bitlen >> 8;
+	ctx->data[61] = ctx->bitlen >> 16;
+	ctx->data[60] = ctx->bitlen >> 24;
+	ctx->data[59] = ctx->bitlen >> 32;
+	ctx->data[58] = ctx->bitlen >> 40;
+	ctx->data[57] = ctx->bitlen >> 48;
+	ctx->data[56] = ctx->bitlen >> 56;
+	sha256_transform(ctx, ctx->data);
+
+	// Since this implementation uses little endian byte ordering and SHA uses big endian,
+	// reverse all the bytes when copying the final state to the output hash.
+	for (i = 0; i < 4; ++i) {
+		hash[i]      = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 4]  = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 8]  = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
+	}
+}

--- a/vendor/B-Con/sha256.h
+++ b/vendor/B-Con/sha256.h
@@ -1,0 +1,47 @@
+//
+//  sha256.h
+//  Monocypher-cpp
+//
+//  Imported by Jens Alfke on 2/9/22.
+//  Source: <https://github.com/B-Con/crypto-algorithms/blob/master/sha256.h>
+//  Changes:
+//      - include <stdint.h>
+//      - Changed BYTE type from `unsigned char` to `uint8_t`
+//      - Changed WORD type from `unsigned int` to `uint32_t`
+//
+
+/*********************************************************************
+* Filename:   sha256.h
+* Author:     Brad Conte (brad AT bradconte.com)
+* Copyright:
+* Disclaimer: This code is presented "as is" without any guarantees.
+* Details:    Defines the API for the corresponding SHA1 implementation.
+*********************************************************************/
+
+#ifndef SHA256_H
+#define SHA256_H
+
+/*************************** HEADER FILES ***************************/
+#include <stddef.h>
+#include <stdint.h>
+
+/****************************** MACROS ******************************/
+#define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
+
+/**************************** DATA TYPES ****************************/
+typedef uint8_t BYTE;             // 8-bit byte
+typedef uint32_t  WORD;             // 32-bit word, change to "long" for 16-bit machines
+
+typedef struct {
+	BYTE data[64];
+	WORD datalen;
+	unsigned long long bitlen;
+	WORD state[8];
+} SHA256_CTX;
+
+/*********************** FUNCTION DECLARATIONS **********************/
+void sha256_init(SHA256_CTX *ctx);
+void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len);
+void sha256_final(SHA256_CTX *ctx, BYTE hash[]);
+
+#endif   // SHA256_H

--- a/vendor/tweetnacl/tweetnacl.c
+++ b/vendor/tweetnacl/tweetnacl.c
@@ -1,0 +1,820 @@
+//
+//  tweetnacl.c
+//  Monocypher-cpp
+//
+//  Imported by Jens Alfke on 2/8/22.
+//  Source: <https://tweetnacl.cr.yp.to/20140427/tweetnacl.c>
+//  Changes:
+//      - Added a few `(int)` casts to fix compiler warnings about implicit conversions.
+//  License:
+//      From the home page: "TweetNaCl is a self-contained public-domain C library"
+
+#include "tweetnacl.h"
+#define FOR(i,n) for (i = 0;i < n;++i)
+#define sv static void
+
+typedef unsigned char u8;
+typedef unsigned long u32;
+typedef unsigned long long u64;
+typedef long long i64;
+typedef i64 gf[16];
+extern void randombytes(u8 *,u64);
+
+static const u8
+  _0[16] = {0},
+  _9[32] = {9};
+static const gf
+  gf0 = {0},
+  gf1 = {1},
+  _121665 = {0xDB41,1},
+  D = {0x78a3, 0x1359, 0x4dca, 0x75eb, 0xd8ab, 0x4141, 0x0a4d, 0x0070, 0xe898, 0x7779, 0x4079, 0x8cc7, 0xfe73, 0x2b6f, 0x6cee, 0x5203},
+  D2 = {0xf159, 0x26b2, 0x9b94, 0xebd6, 0xb156, 0x8283, 0x149a, 0x00e0, 0xd130, 0xeef3, 0x80f2, 0x198e, 0xfce7, 0x56df, 0xd9dc, 0x2406},
+  X = {0xd51a, 0x8f25, 0x2d60, 0xc956, 0xa7b2, 0x9525, 0xc760, 0x692c, 0xdc5c, 0xfdd6, 0xe231, 0xc0a4, 0x53fe, 0xcd6e, 0x36d3, 0x2169},
+  Y = {0x6658, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666, 0x6666},
+  I = {0xa0b0, 0x4a0e, 0x1b27, 0xc4ee, 0xe478, 0xad2f, 0x1806, 0x2f43, 0xd7a7, 0x3dfb, 0x0099, 0x2b4d, 0xdf0b, 0x4fc1, 0x2480, 0x2b83};
+
+static u32 L32(u32 x,int c) { return (x << c) | ((x&0xffffffff) >> (32 - c)); }
+
+static u32 ld32(const u8 *x)
+{
+  u32 u = x[3];
+  u = (u<<8)|x[2];
+  u = (u<<8)|x[1];
+  return (u<<8)|x[0];
+}
+
+static u64 dl64(const u8 *x)
+{
+  u64 i,u=0;
+  FOR(i,8) u=(u<<8)|x[i];
+  return u;
+}
+
+sv st32(u8 *x,u32 u)
+{
+  int i;
+  FOR(i,4) { x[i] = u; u >>= 8; }
+}
+
+sv ts64(u8 *x,u64 u)
+{
+  int i;
+  for (i = 7;i >= 0;--i) { x[i] = u; u >>= 8; }
+}
+
+static int vn(const u8 *x,const u8 *y,int n)
+{
+  u32 i,d = 0;
+  FOR(i,n) d |= x[i]^y[i];
+  return (1 & ((d - 1) >> 8)) - 1;
+}
+
+int crypto_verify_16(const u8 *x,const u8 *y)
+{
+  return vn(x,y,16);
+}
+
+int crypto_verify_32(const u8 *x,const u8 *y)
+{
+  return vn(x,y,32);
+}
+
+sv core(u8 *out,const u8 *in,const u8 *k,const u8 *c,int h)
+{
+  u32 w[16],x[16],y[16],t[4];
+  int i,j,m;
+
+  FOR(i,4) {
+    x[5*i] = ld32(c+4*i);
+    x[1+i] = ld32(k+4*i);
+    x[6+i] = ld32(in+4*i);
+    x[11+i] = ld32(k+16+4*i);
+  }
+
+  FOR(i,16) y[i] = x[i];
+
+  FOR(i,20) {
+    FOR(j,4) {
+      FOR(m,4) t[m] = x[(5*j+4*m)%16];
+      t[1] ^= L32(t[0]+t[3], 7);
+      t[2] ^= L32(t[1]+t[0], 9);
+      t[3] ^= L32(t[2]+t[1],13);
+      t[0] ^= L32(t[3]+t[2],18);
+      FOR(m,4) w[4*j+(j+m)%4] = t[m];
+    }
+    FOR(m,16) x[m] = w[m];
+  }
+
+  if (h) {
+    FOR(i,16) x[i] += y[i];
+    FOR(i,4) {
+      x[5*i] -= ld32(c+4*i);
+      x[6+i] -= ld32(in+4*i);
+    }
+    FOR(i,4) {
+      st32(out+4*i,x[5*i]);
+      st32(out+16+4*i,x[6+i]);
+    }
+  } else
+    FOR(i,16) st32(out + 4 * i,x[i] + y[i]);
+}
+
+int crypto_core_salsa20(u8 *out,const u8 *in,const u8 *k,const u8 *c)
+{
+  core(out,in,k,c,0);
+  return 0;
+}
+
+int crypto_core_hsalsa20(u8 *out,const u8 *in,const u8 *k,const u8 *c)
+{
+  core(out,in,k,c,1);
+  return 0;
+}
+
+static const u8 sigma[17] = "expand 32-byte k";  // compiler makes us count the trailing 0 in size
+
+int crypto_stream_salsa20_xor(u8 *c,const u8 *m,u64 b,const u8 *n,const u8 *k)
+{
+  u8 z[16],x[64];
+  u32 u,i;
+  if (!b) return 0;
+  FOR(i,16) z[i] = 0;
+  FOR(i,8) z[i] = n[i];
+  while (b >= 64) {
+    crypto_core_salsa20(x,z,k,sigma);
+    FOR(i,64) c[i] = (m?m[i]:0) ^ x[i];
+    u = 1;
+    for (i = 8;i < 16;++i) {
+      u += (u32) z[i];
+      z[i] = u;
+      u >>= 8;
+    }
+    b -= 64;
+    c += 64;
+    if (m) m += 64;
+  }
+  if (b) {
+    crypto_core_salsa20(x,z,k,sigma);
+    FOR(i,b) c[i] = (m?m[i]:0) ^ x[i];
+  }
+  return 0;
+}
+
+int crypto_stream_salsa20(u8 *c,u64 d,const u8 *n,const u8 *k)
+{
+  return crypto_stream_salsa20_xor(c,0,d,n,k);
+}
+
+int crypto_stream(u8 *c,u64 d,const u8 *n,const u8 *k)
+{
+  u8 s[32];
+  crypto_core_hsalsa20(s,n,k,sigma);
+  return crypto_stream_salsa20(c,d,n+16,s);
+}
+
+int crypto_stream_xor(u8 *c,const u8 *m,u64 d,const u8 *n,const u8 *k)
+{
+  u8 s[32];
+  crypto_core_hsalsa20(s,n,k,sigma);
+  return crypto_stream_salsa20_xor(c,m,d,n+16,s);
+}
+
+sv add1305(u32 *h,const u32 *c)
+{
+  u32 j,u = 0;
+  FOR(j,17) {
+    u += h[j] + c[j];
+    h[j] = u & 255;
+    u >>= 8;
+  }
+}
+
+static const u32 minusp[17] = {
+  5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 252
+} ;
+
+int crypto_onetimeauth(u8 *out,const u8 *m,u64 n,const u8 *k)
+{
+  u32 s,i,j,u,x[17],r[17],h[17],c[17],g[17];
+
+  FOR(j,17) r[j]=h[j]=0;
+  FOR(j,16) r[j]=k[j];
+  r[3]&=15;
+  r[4]&=252;
+  r[7]&=15;
+  r[8]&=252;
+  r[11]&=15;
+  r[12]&=252;
+  r[15]&=15;
+
+  while (n > 0) {
+    FOR(j,17) c[j] = 0;
+    for (j = 0;(j < 16) && (j < n);++j) c[j] = m[j];
+    c[j] = 1;
+    m += j; n -= j;
+    add1305(h,c);
+    FOR(i,17) {
+      x[i] = 0;
+      FOR(j,17) x[i] += h[j] * ((j <= i) ? r[i - j] : 320 * r[i + 17 - j]);
+    }
+    FOR(i,17) h[i] = x[i];
+    u = 0;
+    FOR(j,16) {
+      u += h[j];
+      h[j] = u & 255;
+      u >>= 8;
+    }
+    u += h[16]; h[16] = u & 3;
+    u = 5 * (u >> 2);
+    FOR(j,16) {
+      u += h[j];
+      h[j] = u & 255;
+      u >>= 8;
+    }
+    u += h[16]; h[16] = u;
+  }
+
+  FOR(j,17) g[j] = h[j];
+  add1305(h,minusp);
+  s = -(h[16] >> 7);
+  FOR(j,17) h[j] ^= s & (g[j] ^ h[j]);
+
+  FOR(j,16) c[j] = k[j + 16];
+  c[16] = 0;
+  add1305(h,c);
+  FOR(j,16) out[j] = h[j];
+  return 0;
+}
+
+int crypto_onetimeauth_verify(const u8 *h,const u8 *m,u64 n,const u8 *k)
+{
+  u8 x[16];
+  crypto_onetimeauth(x,m,n,k);
+  return crypto_verify_16(h,x);
+}
+
+int crypto_secretbox(u8 *c,const u8 *m,u64 d,const u8 *n,const u8 *k)
+{
+  int i;
+  if (d < 32) return -1;
+  crypto_stream_xor(c,m,d,n,k);
+  crypto_onetimeauth(c + 16,c + 32,d - 32,c);
+  FOR(i,16) c[i] = 0;
+  return 0;
+}
+
+int crypto_secretbox_open(u8 *m,const u8 *c,u64 d,const u8 *n,const u8 *k)
+{
+  int i;
+  u8 x[32];
+  if (d < 32) return -1;
+  crypto_stream(x,32,n,k);
+  if (crypto_onetimeauth_verify(c + 16,c + 32,d - 32,x) != 0) return -1;
+  crypto_stream_xor(m,c,d,n,k);
+  FOR(i,32) m[i] = 0;
+  return 0;
+}
+
+sv set25519(gf r, const gf a)
+{
+  int i;
+  FOR(i,16) r[i]=a[i];
+}
+
+sv car25519(gf o)
+{
+  int i;
+  i64 c;
+  FOR(i,16) {
+    o[i]+=(1LL<<16);
+    c=o[i]>>16;
+    o[(i+1)*(i<15)]+=c-1+37*(c-1)*(i==15);
+    o[i]-=c<<16;
+  }
+}
+
+sv sel25519(gf p,gf q,int b)
+{
+  i64 t,i,c=~(b-1);
+  FOR(i,16) {
+    t= c&(p[i]^q[i]);
+    p[i]^=t;
+    q[i]^=t;
+  }
+}
+
+sv pack25519(u8 *o,const gf n)
+{
+  int i,j,b;
+  gf m,t;
+  FOR(i,16) t[i]=n[i];
+  car25519(t);
+  car25519(t);
+  car25519(t);
+  FOR(j,2) {
+    m[0]=t[0]-0xffed;
+    for(i=1;i<15;i++) {
+      m[i]=t[i]-0xffff-((m[i-1]>>16)&1);
+      m[i-1]&=0xffff;
+    }
+    m[15]=t[15]-0x7fff-((m[14]>>16)&1);
+    b=(m[15]>>16)&1;
+    m[14]&=0xffff;
+    sel25519(t,m,1-b);
+  }
+  FOR(i,16) {
+    o[2*i]=t[i]&0xff;
+    o[2*i+1]=t[i]>>8;
+  }
+}
+
+static int neq25519(const gf a, const gf b)
+{
+  u8 c[32],d[32];
+  pack25519(c,a);
+  pack25519(d,b);
+  return crypto_verify_32(c,d);
+}
+
+static u8 par25519(const gf a)
+{
+  u8 d[32];
+  pack25519(d,a);
+  return d[0]&1;
+}
+
+sv unpack25519(gf o, const u8 *n)
+{
+  int i;
+  FOR(i,16) o[i]=n[2*i]+((i64)n[2*i+1]<<8);
+  o[15]&=0x7fff;
+}
+
+sv A(gf o,const gf a,const gf b)
+{
+  int i;
+  FOR(i,16) o[i]=a[i]+b[i];
+}
+
+sv Z(gf o,const gf a,const gf b)
+{
+  int i;
+  FOR(i,16) o[i]=a[i]-b[i];
+}
+
+sv M(gf o,const gf a,const gf b)
+{
+  i64 i,j,t[31];
+  FOR(i,31) t[i]=0;
+  FOR(i,16) FOR(j,16) t[i+j]+=a[i]*b[j];
+  FOR(i,15) t[i]+=38*t[i+16];
+  FOR(i,16) o[i]=t[i];
+  car25519(o);
+  car25519(o);
+}
+
+sv S(gf o,const gf a)
+{
+  M(o,a,a);
+}
+
+sv inv25519(gf o,const gf i)
+{
+  gf c;
+  int a;
+  FOR(a,16) c[a]=i[a];
+  for(a=253;a>=0;a--) {
+    S(c,c);
+    if(a!=2&&a!=4) M(c,c,i);
+  }
+  FOR(a,16) o[a]=c[a];
+}
+
+sv pow2523(gf o,const gf i)
+{
+  gf c;
+  int a;
+  FOR(a,16) c[a]=i[a];
+  for(a=250;a>=0;a--) {
+    S(c,c);
+    if(a!=1) M(c,c,i);
+  }
+  FOR(a,16) o[a]=c[a];
+}
+
+int crypto_scalarmult(u8 *q,const u8 *n,const u8 *p)
+{
+  u8 z[32];
+  i64 x[80],r,i;
+  gf a,b,c,d,e,f;
+  FOR(i,31) z[i]=n[i];
+  z[31]=(n[31]&127)|64;
+  z[0]&=248;
+  unpack25519(x,p);
+  FOR(i,16) {
+    b[i]=x[i];
+    d[i]=a[i]=c[i]=0;
+  }
+  a[0]=d[0]=1;
+  for(i=254;i>=0;--i) {
+    r=(z[i>>3]>>(i&7))&1;
+    sel25519(a,b,(int)r);
+    sel25519(c,d,(int)r);
+    A(e,a,c);
+    Z(a,a,c);
+    A(c,b,d);
+    Z(b,b,d);
+    S(d,e);
+    S(f,a);
+    M(a,c,a);
+    M(c,b,e);
+    A(e,a,c);
+    Z(a,a,c);
+    S(b,a);
+    Z(c,d,f);
+    M(a,c,_121665);
+    A(a,a,d);
+    M(c,c,a);
+    M(a,d,f);
+    M(d,b,x);
+    S(b,e);
+    sel25519(a,b,(int)r);
+    sel25519(c,d,(int)r);
+  }
+  FOR(i,16) {
+    x[i+16]=a[i];
+    x[i+32]=c[i];
+    x[i+48]=b[i];
+    x[i+64]=d[i];
+  }
+  inv25519(x+32,x+32);
+  M(x+16,x+16,x+32);
+  pack25519(q,x+16);
+  return 0;
+}
+
+int crypto_scalarmult_base(u8 *q,const u8 *n)
+{
+  return crypto_scalarmult(q,n,_9);
+}
+
+int crypto_box_keypair(u8 *y,u8 *x)
+{
+  randombytes(x,32);
+  return crypto_scalarmult_base(y,x);
+}
+
+int crypto_box_beforenm(u8 *k,const u8 *y,const u8 *x)
+{
+  u8 s[32];
+  crypto_scalarmult(s,x,y);
+  return crypto_core_hsalsa20(k,_0,s,sigma);
+}
+
+int crypto_box_afternm(u8 *c,const u8 *m,u64 d,const u8 *n,const u8 *k)
+{
+  return crypto_secretbox(c,m,d,n,k);
+}
+
+int crypto_box_open_afternm(u8 *m,const u8 *c,u64 d,const u8 *n,const u8 *k)
+{
+  return crypto_secretbox_open(m,c,d,n,k);
+}
+
+int crypto_box(u8 *c,const u8 *m,u64 d,const u8 *n,const u8 *y,const u8 *x)
+{
+  u8 k[32];
+  crypto_box_beforenm(k,y,x);
+  return crypto_box_afternm(c,m,d,n,k);
+}
+
+int crypto_box_open(u8 *m,const u8 *c,u64 d,const u8 *n,const u8 *y,const u8 *x)
+{
+  u8 k[32];
+  crypto_box_beforenm(k,y,x);
+  return crypto_box_open_afternm(m,c,d,n,k);
+}
+
+static u64 R(u64 x,int c) { return (x >> c) | (x << (64 - c)); }
+static u64 Ch(u64 x,u64 y,u64 z) { return (x & y) ^ (~x & z); }
+static u64 Maj(u64 x,u64 y,u64 z) { return (x & y) ^ (x & z) ^ (y & z); }
+static u64 Sigma0(u64 x) { return R(x,28) ^ R(x,34) ^ R(x,39); }
+static u64 Sigma1(u64 x) { return R(x,14) ^ R(x,18) ^ R(x,41); }
+static u64 sigma0(u64 x) { return R(x, 1) ^ R(x, 8) ^ (x >> 7); }
+static u64 sigma1(u64 x) { return R(x,19) ^ R(x,61) ^ (x >> 6); }
+
+static const u64 K[80] =
+{
+  0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
+  0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL, 0x923f82a4af194f9bULL, 0xab1c5ed5da6d8118ULL,
+  0xd807aa98a3030242ULL, 0x12835b0145706fbeULL, 0x243185be4ee4b28cULL, 0x550c7dc3d5ffb4e2ULL,
+  0x72be5d74f27b896fULL, 0x80deb1fe3b1696b1ULL, 0x9bdc06a725c71235ULL, 0xc19bf174cf692694ULL,
+  0xe49b69c19ef14ad2ULL, 0xefbe4786384f25e3ULL, 0x0fc19dc68b8cd5b5ULL, 0x240ca1cc77ac9c65ULL,
+  0x2de92c6f592b0275ULL, 0x4a7484aa6ea6e483ULL, 0x5cb0a9dcbd41fbd4ULL, 0x76f988da831153b5ULL,
+  0x983e5152ee66dfabULL, 0xa831c66d2db43210ULL, 0xb00327c898fb213fULL, 0xbf597fc7beef0ee4ULL,
+  0xc6e00bf33da88fc2ULL, 0xd5a79147930aa725ULL, 0x06ca6351e003826fULL, 0x142929670a0e6e70ULL,
+  0x27b70a8546d22ffcULL, 0x2e1b21385c26c926ULL, 0x4d2c6dfc5ac42aedULL, 0x53380d139d95b3dfULL,
+  0x650a73548baf63deULL, 0x766a0abb3c77b2a8ULL, 0x81c2c92e47edaee6ULL, 0x92722c851482353bULL,
+  0xa2bfe8a14cf10364ULL, 0xa81a664bbc423001ULL, 0xc24b8b70d0f89791ULL, 0xc76c51a30654be30ULL,
+  0xd192e819d6ef5218ULL, 0xd69906245565a910ULL, 0xf40e35855771202aULL, 0x106aa07032bbd1b8ULL,
+  0x19a4c116b8d2d0c8ULL, 0x1e376c085141ab53ULL, 0x2748774cdf8eeb99ULL, 0x34b0bcb5e19b48a8ULL,
+  0x391c0cb3c5c95a63ULL, 0x4ed8aa4ae3418acbULL, 0x5b9cca4f7763e373ULL, 0x682e6ff3d6b2b8a3ULL,
+  0x748f82ee5defb2fcULL, 0x78a5636f43172f60ULL, 0x84c87814a1f0ab72ULL, 0x8cc702081a6439ecULL,
+  0x90befffa23631e28ULL, 0xa4506cebde82bde9ULL, 0xbef9a3f7b2c67915ULL, 0xc67178f2e372532bULL,
+  0xca273eceea26619cULL, 0xd186b8c721c0c207ULL, 0xeada7dd6cde0eb1eULL, 0xf57d4f7fee6ed178ULL,
+  0x06f067aa72176fbaULL, 0x0a637dc5a2c898a6ULL, 0x113f9804bef90daeULL, 0x1b710b35131c471bULL,
+  0x28db77f523047d84ULL, 0x32caab7b40c72493ULL, 0x3c9ebe0a15c9bebcULL, 0x431d67c49c100d4cULL,
+  0x4cc5d4becb3e42b6ULL, 0x597f299cfc657e2aULL, 0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
+};
+
+int crypto_hashblocks(u8 *x,const u8 *m,u64 n)
+{
+  u64 z[8],b[8],a[8],w[16],t;
+  int i,j;
+
+  FOR(i,8) z[i] = a[i] = dl64(x + 8 * i);
+
+  while (n >= 128) {
+    FOR(i,16) w[i] = dl64(m + 8 * i);
+
+    FOR(i,80) {
+      FOR(j,8) b[j] = a[j];
+      t = a[7] + Sigma1(a[4]) + Ch(a[4],a[5],a[6]) + K[i] + w[i%16];
+      b[7] = t + Sigma0(a[0]) + Maj(a[0],a[1],a[2]);
+      b[3] += t;
+      FOR(j,8) a[(j+1)%8] = b[j];
+      if (i%16 == 15)
+	FOR(j,16)
+	  w[j] += w[(j+9)%16] + sigma0(w[(j+1)%16]) + sigma1(w[(j+14)%16]);
+    }
+
+    FOR(i,8) { a[i] += z[i]; z[i] = a[i]; }
+
+    m += 128;
+    n -= 128;
+  }
+
+  FOR(i,8) ts64(x+8*i,z[i]);
+
+  return (int)n;
+}
+
+static const u8 iv[64] = {
+  0x6a,0x09,0xe6,0x67,0xf3,0xbc,0xc9,0x08,
+  0xbb,0x67,0xae,0x85,0x84,0xca,0xa7,0x3b,
+  0x3c,0x6e,0xf3,0x72,0xfe,0x94,0xf8,0x2b,
+  0xa5,0x4f,0xf5,0x3a,0x5f,0x1d,0x36,0xf1,
+  0x51,0x0e,0x52,0x7f,0xad,0xe6,0x82,0xd1,
+  0x9b,0x05,0x68,0x8c,0x2b,0x3e,0x6c,0x1f,
+  0x1f,0x83,0xd9,0xab,0xfb,0x41,0xbd,0x6b,
+  0x5b,0xe0,0xcd,0x19,0x13,0x7e,0x21,0x79
+} ;
+
+int crypto_hash(u8 *out,const u8 *m,u64 n)
+{
+  u8 h[64],x[256];
+  u64 i,b = n;
+
+  FOR(i,64) h[i] = iv[i];
+
+  crypto_hashblocks(h,m,n);
+  m += n;
+  n &= 127;
+  m -= n;
+
+  FOR(i,256) x[i] = 0;
+  FOR(i,n) x[i] = m[i];
+  x[n] = 128;
+
+  n = 256-128*(n<112);
+  x[n-9] = b >> 61;
+  ts64(x+n-8,b<<3);
+  crypto_hashblocks(h,x,n);
+
+  FOR(i,64) out[i] = h[i];
+
+  return 0;
+}
+
+sv add(gf p[4],gf q[4])
+{
+  gf a,b,c,d,t,e,f,g,h;
+
+  Z(a, p[1], p[0]);
+  Z(t, q[1], q[0]);
+  M(a, a, t);
+  A(b, p[0], p[1]);
+  A(t, q[0], q[1]);
+  M(b, b, t);
+  M(c, p[3], q[3]);
+  M(c, c, D2);
+  M(d, p[2], q[2]);
+  A(d, d, d);
+  Z(e, b, a);
+  Z(f, d, c);
+  A(g, d, c);
+  A(h, b, a);
+
+  M(p[0], e, f);
+  M(p[1], h, g);
+  M(p[2], g, f);
+  M(p[3], e, h);
+}
+
+sv cswap(gf p[4],gf q[4],u8 b)
+{
+  int i;
+  FOR(i,4)
+    sel25519(p[i],q[i],b);
+}
+
+sv pack(u8 *r,gf p[4])
+{
+  gf tx, ty, zi;
+  inv25519(zi, p[2]);
+  M(tx, p[0], zi);
+  M(ty, p[1], zi);
+  pack25519(r, ty);
+  r[31] ^= par25519(tx) << 7;
+}
+
+sv scalarmult(gf p[4],gf q[4],const u8 *s)
+{
+  int i;
+  set25519(p[0],gf0);
+  set25519(p[1],gf1);
+  set25519(p[2],gf1);
+  set25519(p[3],gf0);
+  for (i = 255;i >= 0;--i) {
+    u8 b = (s[i/8]>>(i&7))&1;
+    cswap(p,q,b);
+    add(q,p);
+    add(p,p);
+    cswap(p,q,b);
+  }
+}
+
+sv scalarbase(gf p[4],const u8 *s)
+{
+  gf q[4];
+  set25519(q[0],X);
+  set25519(q[1],Y);
+  set25519(q[2],gf1);
+  M(q[3],X,Y);
+  scalarmult(p,q,s);
+}
+
+int crypto_sign_keypair(u8 *pk, u8 *sk)
+{
+  u8 d[64];
+  gf p[4];
+  int i;
+
+  randombytes(sk, 32);
+  crypto_hash(d, sk, 32);
+  d[0] &= 248;
+  d[31] &= 127;
+  d[31] |= 64;
+
+  scalarbase(p,d);
+  pack(pk,p);
+
+  FOR(i,32) sk[32 + i] = pk[i];
+  return 0;
+}
+
+static const u64 L[32] = {0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x10};
+
+sv modL(u8 *r,i64 x[64])
+{
+  i64 carry,i,j;
+  for (i = 63;i >= 32;--i) {
+    carry = 0;
+    for (j = i - 32;j < i - 12;++j) {
+      x[j] += carry - 16 * x[i] * L[j - (i - 32)];
+      carry = (x[j] + 128) >> 8;
+      x[j] -= carry << 8;
+    }
+    x[j] += carry;
+    x[i] = 0;
+  }
+  carry = 0;
+  FOR(j,32) {
+    x[j] += carry - (x[31] >> 4) * L[j];
+    carry = x[j] >> 8;
+    x[j] &= 255;
+  }
+  FOR(j,32) x[j] -= carry * L[j];
+  FOR(i,32) {
+    x[i+1] += x[i] >> 8;
+    r[i] = x[i] & 255;
+  }
+}
+
+sv reduce(u8 *r)
+{
+  i64 x[64],i;
+  FOR(i,64) x[i] = (u64) r[i];
+  FOR(i,64) r[i] = 0;
+  modL(r,x);
+}
+
+int crypto_sign(u8 *sm,u64 *smlen,const u8 *m,u64 n,const u8 *sk)
+{
+  u8 d[64],h[64],r[64];
+  i64 i,j,x[64];
+  gf p[4];
+
+  crypto_hash(d, sk, 32);
+  d[0] &= 248;
+  d[31] &= 127;
+  d[31] |= 64;
+
+  *smlen = n+64;
+  FOR(i,n) sm[64 + i] = m[i];
+  FOR(i,32) sm[32 + i] = d[32 + i];
+
+  crypto_hash(r, sm+32, n+32);
+  reduce(r);
+  scalarbase(p,r);
+  pack(sm,p);
+
+  FOR(i,32) sm[i+32] = sk[i+32];
+  crypto_hash(h,sm,n + 64);
+  reduce(h);
+
+  FOR(i,64) x[i] = 0;
+  FOR(i,32) x[i] = (u64) r[i];
+  FOR(i,32) FOR(j,32) x[i+j] += h[i] * (u64) d[j];
+  modL(sm + 32,x);
+
+  return 0;
+}
+
+static int unpackneg(gf r[4],const u8 p[32])
+{
+  gf t, chk, num, den, den2, den4, den6;
+  set25519(r[2],gf1);
+  unpack25519(r[1],p);
+  S(num,r[1]);
+  M(den,num,D);
+  Z(num,num,r[2]);
+  A(den,r[2],den);
+
+  S(den2,den);
+  S(den4,den2);
+  M(den6,den4,den2);
+  M(t,den6,num);
+  M(t,t,den);
+
+  pow2523(t,t);
+  M(t,t,num);
+  M(t,t,den);
+  M(t,t,den);
+  M(r[0],t,den);
+
+  S(chk,r[0]);
+  M(chk,chk,den);
+  if (neq25519(chk, num)) M(r[0],r[0],I);
+
+  S(chk,r[0]);
+  M(chk,chk,den);
+  if (neq25519(chk, num)) return -1;
+
+  if (par25519(r[0]) == (p[31]>>7)) Z(r[0],gf0,r[0]);
+
+  M(r[3],r[0],r[1]);
+  return 0;
+}
+
+int crypto_sign_open(u8 *m,u64 *mlen,const u8 *sm,u64 n,const u8 *pk)
+{
+  int i;
+  u8 t[32],h[64];
+  gf p[4],q[4];
+
+  *mlen = -1;
+  if (n < 64) return -1;
+
+  if (unpackneg(q,pk)) return -1;
+
+  FOR(i,n) m[i] = sm[i];
+  FOR(i,32) m[i+32] = pk[i];
+  crypto_hash(h,m,n);
+  reduce(h);
+  scalarmult(p,q,h);
+
+  scalarbase(q,sm + 32);
+  add(p,q);
+  pack(t,p);
+
+  n -= 64;
+  if (crypto_verify_32(sm, t)) {
+    FOR(i,n) m[i] = 0;
+    return -1;
+  }
+
+  FOR(i,n) m[i] = sm[i + 64];
+  *mlen = n;
+  return 0;
+}

--- a/vendor/tweetnacl/tweetnacl.h
+++ b/vendor/tweetnacl/tweetnacl.h
@@ -1,0 +1,281 @@
+//
+//  tweetnacl.h
+//  Monocypher-cpp
+//
+//  Imported from: <https://tweetnacl.cr.yp.to/20140427/tweetnacl.h>
+//  by Jens Alfke on 2/8/22.
+//
+
+#ifndef TWEETNACL_H
+#define TWEETNACL_H
+
+#define crypto_auth_PRIMITIVE "hmacsha512256"
+#define crypto_auth crypto_auth_hmacsha512256
+#define crypto_auth_verify crypto_auth_hmacsha512256_verify
+#define crypto_auth_BYTES crypto_auth_hmacsha512256_BYTES
+#define crypto_auth_KEYBYTES crypto_auth_hmacsha512256_KEYBYTES
+#define crypto_auth_IMPLEMENTATION crypto_auth_hmacsha512256_IMPLEMENTATION
+#define crypto_auth_VERSION crypto_auth_hmacsha512256_VERSION
+#define crypto_auth_hmacsha512256_tweet_BYTES 32
+#define crypto_auth_hmacsha512256_tweet_KEYBYTES 32
+extern int crypto_auth_hmacsha512256_tweet(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+extern int crypto_auth_hmacsha512256_tweet_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+#define crypto_auth_hmacsha512256_tweet_VERSION "-"
+#define crypto_auth_hmacsha512256 crypto_auth_hmacsha512256_tweet
+#define crypto_auth_hmacsha512256_verify crypto_auth_hmacsha512256_tweet_verify
+#define crypto_auth_hmacsha512256_BYTES crypto_auth_hmacsha512256_tweet_BYTES
+#define crypto_auth_hmacsha512256_KEYBYTES crypto_auth_hmacsha512256_tweet_KEYBYTES
+#define crypto_auth_hmacsha512256_VERSION crypto_auth_hmacsha512256_tweet_VERSION
+#define crypto_auth_hmacsha512256_IMPLEMENTATION "crypto_auth/hmacsha512256/tweet"
+#define crypto_box_PRIMITIVE "curve25519xsalsa20poly1305"
+#define crypto_box crypto_box_curve25519xsalsa20poly1305
+#define crypto_box_open crypto_box_curve25519xsalsa20poly1305_open
+#define crypto_box_keypair crypto_box_curve25519xsalsa20poly1305_keypair
+#define crypto_box_beforenm crypto_box_curve25519xsalsa20poly1305_beforenm
+#define crypto_box_afternm crypto_box_curve25519xsalsa20poly1305_afternm
+#define crypto_box_open_afternm crypto_box_curve25519xsalsa20poly1305_open_afternm
+#define crypto_box_PUBLICKEYBYTES crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES
+#define crypto_box_SECRETKEYBYTES crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES
+#define crypto_box_BEFORENMBYTES crypto_box_curve25519xsalsa20poly1305_BEFORENMBYTES
+#define crypto_box_NONCEBYTES crypto_box_curve25519xsalsa20poly1305_NONCEBYTES
+#define crypto_box_ZEROBYTES crypto_box_curve25519xsalsa20poly1305_ZEROBYTES
+#define crypto_box_BOXZEROBYTES crypto_box_curve25519xsalsa20poly1305_BOXZEROBYTES
+#define crypto_box_IMPLEMENTATION crypto_box_curve25519xsalsa20poly1305_IMPLEMENTATION
+#define crypto_box_VERSION crypto_box_curve25519xsalsa20poly1305_VERSION
+#define crypto_box_curve25519xsalsa20poly1305_tweet_PUBLICKEYBYTES 32
+#define crypto_box_curve25519xsalsa20poly1305_tweet_SECRETKEYBYTES 32
+#define crypto_box_curve25519xsalsa20poly1305_tweet_BEFORENMBYTES 32
+#define crypto_box_curve25519xsalsa20poly1305_tweet_NONCEBYTES 24
+#define crypto_box_curve25519xsalsa20poly1305_tweet_ZEROBYTES 32
+#define crypto_box_curve25519xsalsa20poly1305_tweet_BOXZEROBYTES 16
+extern int crypto_box_curve25519xsalsa20poly1305_tweet(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
+extern int crypto_box_curve25519xsalsa20poly1305_tweet_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *,const unsigned char *);
+extern int crypto_box_curve25519xsalsa20poly1305_tweet_keypair(unsigned char *,unsigned char *);
+extern int crypto_box_curve25519xsalsa20poly1305_tweet_beforenm(unsigned char *,const unsigned char *,const unsigned char *);
+extern int crypto_box_curve25519xsalsa20poly1305_tweet_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+extern int crypto_box_curve25519xsalsa20poly1305_tweet_open_afternm(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+#define crypto_box_curve25519xsalsa20poly1305_tweet_VERSION "-"
+#define crypto_box_curve25519xsalsa20poly1305 crypto_box_curve25519xsalsa20poly1305_tweet
+#define crypto_box_curve25519xsalsa20poly1305_open crypto_box_curve25519xsalsa20poly1305_tweet_open
+#define crypto_box_curve25519xsalsa20poly1305_keypair crypto_box_curve25519xsalsa20poly1305_tweet_keypair
+#define crypto_box_curve25519xsalsa20poly1305_beforenm crypto_box_curve25519xsalsa20poly1305_tweet_beforenm
+#define crypto_box_curve25519xsalsa20poly1305_afternm crypto_box_curve25519xsalsa20poly1305_tweet_afternm
+#define crypto_box_curve25519xsalsa20poly1305_open_afternm crypto_box_curve25519xsalsa20poly1305_tweet_open_afternm
+#define crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES crypto_box_curve25519xsalsa20poly1305_tweet_PUBLICKEYBYTES
+#define crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES crypto_box_curve25519xsalsa20poly1305_tweet_SECRETKEYBYTES
+#define crypto_box_curve25519xsalsa20poly1305_BEFORENMBYTES crypto_box_curve25519xsalsa20poly1305_tweet_BEFORENMBYTES
+#define crypto_box_curve25519xsalsa20poly1305_NONCEBYTES crypto_box_curve25519xsalsa20poly1305_tweet_NONCEBYTES
+#define crypto_box_curve25519xsalsa20poly1305_ZEROBYTES crypto_box_curve25519xsalsa20poly1305_tweet_ZEROBYTES
+#define crypto_box_curve25519xsalsa20poly1305_BOXZEROBYTES crypto_box_curve25519xsalsa20poly1305_tweet_BOXZEROBYTES
+#define crypto_box_curve25519xsalsa20poly1305_VERSION crypto_box_curve25519xsalsa20poly1305_tweet_VERSION
+#define crypto_box_curve25519xsalsa20poly1305_IMPLEMENTATION "crypto_box/curve25519xsalsa20poly1305/tweet"
+#define crypto_core_PRIMITIVE "salsa20"
+#define crypto_core crypto_core_salsa20
+#define crypto_core_OUTPUTBYTES crypto_core_salsa20_OUTPUTBYTES
+#define crypto_core_INPUTBYTES crypto_core_salsa20_INPUTBYTES
+#define crypto_core_KEYBYTES crypto_core_salsa20_KEYBYTES
+#define crypto_core_CONSTBYTES crypto_core_salsa20_CONSTBYTES
+#define crypto_core_IMPLEMENTATION crypto_core_salsa20_IMPLEMENTATION
+#define crypto_core_VERSION crypto_core_salsa20_VERSION
+#define crypto_core_salsa20_tweet_OUTPUTBYTES 64
+#define crypto_core_salsa20_tweet_INPUTBYTES 16
+#define crypto_core_salsa20_tweet_KEYBYTES 32
+#define crypto_core_salsa20_tweet_CONSTBYTES 16
+extern int crypto_core_salsa20_tweet(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
+#define crypto_core_salsa20_tweet_VERSION "-"
+#define crypto_core_salsa20 crypto_core_salsa20_tweet
+#define crypto_core_salsa20_OUTPUTBYTES crypto_core_salsa20_tweet_OUTPUTBYTES
+#define crypto_core_salsa20_INPUTBYTES crypto_core_salsa20_tweet_INPUTBYTES
+#define crypto_core_salsa20_KEYBYTES crypto_core_salsa20_tweet_KEYBYTES
+#define crypto_core_salsa20_CONSTBYTES crypto_core_salsa20_tweet_CONSTBYTES
+#define crypto_core_salsa20_VERSION crypto_core_salsa20_tweet_VERSION
+#define crypto_core_salsa20_IMPLEMENTATION "crypto_core/salsa20/tweet"
+#define crypto_core_hsalsa20_tweet_OUTPUTBYTES 32
+#define crypto_core_hsalsa20_tweet_INPUTBYTES 16
+#define crypto_core_hsalsa20_tweet_KEYBYTES 32
+#define crypto_core_hsalsa20_tweet_CONSTBYTES 16
+extern int crypto_core_hsalsa20_tweet(unsigned char *,const unsigned char *,const unsigned char *,const unsigned char *);
+#define crypto_core_hsalsa20_tweet_VERSION "-"
+#define crypto_core_hsalsa20 crypto_core_hsalsa20_tweet
+#define crypto_core_hsalsa20_OUTPUTBYTES crypto_core_hsalsa20_tweet_OUTPUTBYTES
+#define crypto_core_hsalsa20_INPUTBYTES crypto_core_hsalsa20_tweet_INPUTBYTES
+#define crypto_core_hsalsa20_KEYBYTES crypto_core_hsalsa20_tweet_KEYBYTES
+#define crypto_core_hsalsa20_CONSTBYTES crypto_core_hsalsa20_tweet_CONSTBYTES
+#define crypto_core_hsalsa20_VERSION crypto_core_hsalsa20_tweet_VERSION
+#define crypto_core_hsalsa20_IMPLEMENTATION "crypto_core/hsalsa20/tweet"
+#define crypto_hashblocks_PRIMITIVE "sha512"
+#define crypto_hashblocks crypto_hashblocks_sha512
+#define crypto_hashblocks_STATEBYTES crypto_hashblocks_sha512_STATEBYTES
+#define crypto_hashblocks_BLOCKBYTES crypto_hashblocks_sha512_BLOCKBYTES
+#define crypto_hashblocks_IMPLEMENTATION crypto_hashblocks_sha512_IMPLEMENTATION
+#define crypto_hashblocks_VERSION crypto_hashblocks_sha512_VERSION
+#define crypto_hashblocks_sha512_tweet_STATEBYTES 64
+#define crypto_hashblocks_sha512_tweet_BLOCKBYTES 128
+extern int crypto_hashblocks_sha512_tweet(unsigned char *,const unsigned char *,unsigned long long);
+#define crypto_hashblocks_sha512_tweet_VERSION "-"
+#define crypto_hashblocks_sha512 crypto_hashblocks_sha512_tweet
+#define crypto_hashblocks_sha512_STATEBYTES crypto_hashblocks_sha512_tweet_STATEBYTES
+#define crypto_hashblocks_sha512_BLOCKBYTES crypto_hashblocks_sha512_tweet_BLOCKBYTES
+#define crypto_hashblocks_sha512_VERSION crypto_hashblocks_sha512_tweet_VERSION
+#define crypto_hashblocks_sha512_IMPLEMENTATION "crypto_hashblocks/sha512/tweet"
+#define crypto_hashblocks_sha256_tweet_STATEBYTES 32
+#define crypto_hashblocks_sha256_tweet_BLOCKBYTES 64
+extern int crypto_hashblocks_sha256_tweet(unsigned char *,const unsigned char *,unsigned long long);
+#define crypto_hashblocks_sha256_tweet_VERSION "-"
+#define crypto_hashblocks_sha256 crypto_hashblocks_sha256_tweet
+#define crypto_hashblocks_sha256_STATEBYTES crypto_hashblocks_sha256_tweet_STATEBYTES
+#define crypto_hashblocks_sha256_BLOCKBYTES crypto_hashblocks_sha256_tweet_BLOCKBYTES
+#define crypto_hashblocks_sha256_VERSION crypto_hashblocks_sha256_tweet_VERSION
+#define crypto_hashblocks_sha256_IMPLEMENTATION "crypto_hashblocks/sha256/tweet"
+#define crypto_hash_PRIMITIVE "sha512"
+#define crypto_hash crypto_hash_sha512
+#define crypto_hash_BYTES crypto_hash_sha512_BYTES
+#define crypto_hash_IMPLEMENTATION crypto_hash_sha512_IMPLEMENTATION
+#define crypto_hash_VERSION crypto_hash_sha512_VERSION
+#define crypto_hash_sha512_tweet_BYTES 64
+extern int crypto_hash_sha512_tweet(unsigned char *,const unsigned char *,unsigned long long);
+#define crypto_hash_sha512_tweet_VERSION "-"
+#define crypto_hash_sha512 crypto_hash_sha512_tweet
+#define crypto_hash_sha512_BYTES crypto_hash_sha512_tweet_BYTES
+#define crypto_hash_sha512_VERSION crypto_hash_sha512_tweet_VERSION
+#define crypto_hash_sha512_IMPLEMENTATION "crypto_hash/sha512/tweet"
+#define crypto_hash_sha256_tweet_BYTES 32
+extern int crypto_hash_sha256_tweet(unsigned char *,const unsigned char *,unsigned long long);
+#define crypto_hash_sha256_tweet_VERSION "-"
+#define crypto_hash_sha256 crypto_hash_sha256_tweet
+#define crypto_hash_sha256_BYTES crypto_hash_sha256_tweet_BYTES
+#define crypto_hash_sha256_VERSION crypto_hash_sha256_tweet_VERSION
+#define crypto_hash_sha256_IMPLEMENTATION "crypto_hash/sha256/tweet"
+#define crypto_onetimeauth_PRIMITIVE "poly1305"
+#define crypto_onetimeauth crypto_onetimeauth_poly1305
+#define crypto_onetimeauth_verify crypto_onetimeauth_poly1305_verify
+#define crypto_onetimeauth_BYTES crypto_onetimeauth_poly1305_BYTES
+#define crypto_onetimeauth_KEYBYTES crypto_onetimeauth_poly1305_KEYBYTES
+#define crypto_onetimeauth_IMPLEMENTATION crypto_onetimeauth_poly1305_IMPLEMENTATION
+#define crypto_onetimeauth_VERSION crypto_onetimeauth_poly1305_VERSION
+#define crypto_onetimeauth_poly1305_tweet_BYTES 16
+#define crypto_onetimeauth_poly1305_tweet_KEYBYTES 32
+extern int crypto_onetimeauth_poly1305_tweet(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+extern int crypto_onetimeauth_poly1305_tweet_verify(const unsigned char *,const unsigned char *,unsigned long long,const unsigned char *);
+#define crypto_onetimeauth_poly1305_tweet_VERSION "-"
+#define crypto_onetimeauth_poly1305 crypto_onetimeauth_poly1305_tweet
+#define crypto_onetimeauth_poly1305_verify crypto_onetimeauth_poly1305_tweet_verify
+#define crypto_onetimeauth_poly1305_BYTES crypto_onetimeauth_poly1305_tweet_BYTES
+#define crypto_onetimeauth_poly1305_KEYBYTES crypto_onetimeauth_poly1305_tweet_KEYBYTES
+#define crypto_onetimeauth_poly1305_VERSION crypto_onetimeauth_poly1305_tweet_VERSION
+#define crypto_onetimeauth_poly1305_IMPLEMENTATION "crypto_onetimeauth/poly1305/tweet"
+#define crypto_scalarmult_PRIMITIVE "curve25519"
+#define crypto_scalarmult crypto_scalarmult_curve25519
+#define crypto_scalarmult_base crypto_scalarmult_curve25519_base
+#define crypto_scalarmult_BYTES crypto_scalarmult_curve25519_BYTES
+#define crypto_scalarmult_SCALARBYTES crypto_scalarmult_curve25519_SCALARBYTES
+#define crypto_scalarmult_IMPLEMENTATION crypto_scalarmult_curve25519_IMPLEMENTATION
+#define crypto_scalarmult_VERSION crypto_scalarmult_curve25519_VERSION
+#define crypto_scalarmult_curve25519_tweet_BYTES 32
+#define crypto_scalarmult_curve25519_tweet_SCALARBYTES 32
+extern int crypto_scalarmult_curve25519_tweet(unsigned char *,const unsigned char *,const unsigned char *);
+extern int crypto_scalarmult_curve25519_tweet_base(unsigned char *,const unsigned char *);
+#define crypto_scalarmult_curve25519_tweet_VERSION "-"
+#define crypto_scalarmult_curve25519 crypto_scalarmult_curve25519_tweet
+#define crypto_scalarmult_curve25519_base crypto_scalarmult_curve25519_tweet_base
+#define crypto_scalarmult_curve25519_BYTES crypto_scalarmult_curve25519_tweet_BYTES
+#define crypto_scalarmult_curve25519_SCALARBYTES crypto_scalarmult_curve25519_tweet_SCALARBYTES
+#define crypto_scalarmult_curve25519_VERSION crypto_scalarmult_curve25519_tweet_VERSION
+#define crypto_scalarmult_curve25519_IMPLEMENTATION "crypto_scalarmult/curve25519/tweet"
+#define crypto_secretbox_PRIMITIVE "xsalsa20poly1305"
+#define crypto_secretbox crypto_secretbox_xsalsa20poly1305
+#define crypto_secretbox_open crypto_secretbox_xsalsa20poly1305_open
+#define crypto_secretbox_KEYBYTES crypto_secretbox_xsalsa20poly1305_KEYBYTES
+#define crypto_secretbox_NONCEBYTES crypto_secretbox_xsalsa20poly1305_NONCEBYTES
+#define crypto_secretbox_ZEROBYTES crypto_secretbox_xsalsa20poly1305_ZEROBYTES
+#define crypto_secretbox_BOXZEROBYTES crypto_secretbox_xsalsa20poly1305_BOXZEROBYTES
+#define crypto_secretbox_IMPLEMENTATION crypto_secretbox_xsalsa20poly1305_IMPLEMENTATION
+#define crypto_secretbox_VERSION crypto_secretbox_xsalsa20poly1305_VERSION
+#define crypto_secretbox_xsalsa20poly1305_tweet_KEYBYTES 32
+#define crypto_secretbox_xsalsa20poly1305_tweet_NONCEBYTES 24
+#define crypto_secretbox_xsalsa20poly1305_tweet_ZEROBYTES 32
+#define crypto_secretbox_xsalsa20poly1305_tweet_BOXZEROBYTES 16
+extern int crypto_secretbox_xsalsa20poly1305_tweet(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+extern int crypto_secretbox_xsalsa20poly1305_tweet_open(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+#define crypto_secretbox_xsalsa20poly1305_tweet_VERSION "-"
+#define crypto_secretbox_xsalsa20poly1305 crypto_secretbox_xsalsa20poly1305_tweet
+#define crypto_secretbox_xsalsa20poly1305_open crypto_secretbox_xsalsa20poly1305_tweet_open
+#define crypto_secretbox_xsalsa20poly1305_KEYBYTES crypto_secretbox_xsalsa20poly1305_tweet_KEYBYTES
+#define crypto_secretbox_xsalsa20poly1305_NONCEBYTES crypto_secretbox_xsalsa20poly1305_tweet_NONCEBYTES
+#define crypto_secretbox_xsalsa20poly1305_ZEROBYTES crypto_secretbox_xsalsa20poly1305_tweet_ZEROBYTES
+#define crypto_secretbox_xsalsa20poly1305_BOXZEROBYTES crypto_secretbox_xsalsa20poly1305_tweet_BOXZEROBYTES
+#define crypto_secretbox_xsalsa20poly1305_VERSION crypto_secretbox_xsalsa20poly1305_tweet_VERSION
+#define crypto_secretbox_xsalsa20poly1305_IMPLEMENTATION "crypto_secretbox/xsalsa20poly1305/tweet"
+#define crypto_sign_PRIMITIVE "ed25519"
+#define crypto_sign crypto_sign_ed25519
+#define crypto_sign_open crypto_sign_ed25519_open
+#define crypto_sign_keypair crypto_sign_ed25519_keypair
+#define crypto_sign_BYTES crypto_sign_ed25519_BYTES
+#define crypto_sign_PUBLICKEYBYTES crypto_sign_ed25519_PUBLICKEYBYTES
+#define crypto_sign_SECRETKEYBYTES crypto_sign_ed25519_SECRETKEYBYTES
+#define crypto_sign_IMPLEMENTATION crypto_sign_ed25519_IMPLEMENTATION
+#define crypto_sign_VERSION crypto_sign_ed25519_VERSION
+#define crypto_sign_ed25519_tweet_BYTES 64
+#define crypto_sign_ed25519_tweet_PUBLICKEYBYTES 32
+#define crypto_sign_ed25519_tweet_SECRETKEYBYTES 64
+extern int crypto_sign_ed25519_tweet(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+extern int crypto_sign_ed25519_tweet_open(unsigned char *,unsigned long long *,const unsigned char *,unsigned long long,const unsigned char *);
+extern int crypto_sign_ed25519_tweet_keypair(unsigned char *,unsigned char *);
+#define crypto_sign_ed25519_tweet_VERSION "-"
+#define crypto_sign_ed25519 crypto_sign_ed25519_tweet
+#define crypto_sign_ed25519_open crypto_sign_ed25519_tweet_open
+#define crypto_sign_ed25519_keypair crypto_sign_ed25519_tweet_keypair
+#define crypto_sign_ed25519_BYTES crypto_sign_ed25519_tweet_BYTES
+#define crypto_sign_ed25519_PUBLICKEYBYTES crypto_sign_ed25519_tweet_PUBLICKEYBYTES
+#define crypto_sign_ed25519_SECRETKEYBYTES crypto_sign_ed25519_tweet_SECRETKEYBYTES
+#define crypto_sign_ed25519_VERSION crypto_sign_ed25519_tweet_VERSION
+#define crypto_sign_ed25519_IMPLEMENTATION "crypto_sign/ed25519/tweet"
+#define crypto_stream_PRIMITIVE "xsalsa20"
+#define crypto_stream crypto_stream_xsalsa20
+#define crypto_stream_xor crypto_stream_xsalsa20_xor
+#define crypto_stream_KEYBYTES crypto_stream_xsalsa20_KEYBYTES
+#define crypto_stream_NONCEBYTES crypto_stream_xsalsa20_NONCEBYTES
+#define crypto_stream_IMPLEMENTATION crypto_stream_xsalsa20_IMPLEMENTATION
+#define crypto_stream_VERSION crypto_stream_xsalsa20_VERSION
+#define crypto_stream_xsalsa20_tweet_KEYBYTES 32
+#define crypto_stream_xsalsa20_tweet_NONCEBYTES 24
+extern int crypto_stream_xsalsa20_tweet(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+extern int crypto_stream_xsalsa20_tweet_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+#define crypto_stream_xsalsa20_tweet_VERSION "-"
+#define crypto_stream_xsalsa20 crypto_stream_xsalsa20_tweet
+#define crypto_stream_xsalsa20_xor crypto_stream_xsalsa20_tweet_xor
+#define crypto_stream_xsalsa20_KEYBYTES crypto_stream_xsalsa20_tweet_KEYBYTES
+#define crypto_stream_xsalsa20_NONCEBYTES crypto_stream_xsalsa20_tweet_NONCEBYTES
+#define crypto_stream_xsalsa20_VERSION crypto_stream_xsalsa20_tweet_VERSION
+#define crypto_stream_xsalsa20_IMPLEMENTATION "crypto_stream/xsalsa20/tweet"
+#define crypto_stream_salsa20_tweet_KEYBYTES 32
+#define crypto_stream_salsa20_tweet_NONCEBYTES 8
+extern int crypto_stream_salsa20_tweet(unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+extern int crypto_stream_salsa20_tweet_xor(unsigned char *,const unsigned char *,unsigned long long,const unsigned char *,const unsigned char *);
+#define crypto_stream_salsa20_tweet_VERSION "-"
+#define crypto_stream_salsa20 crypto_stream_salsa20_tweet
+#define crypto_stream_salsa20_xor crypto_stream_salsa20_tweet_xor
+#define crypto_stream_salsa20_KEYBYTES crypto_stream_salsa20_tweet_KEYBYTES
+#define crypto_stream_salsa20_NONCEBYTES crypto_stream_salsa20_tweet_NONCEBYTES
+#define crypto_stream_salsa20_VERSION crypto_stream_salsa20_tweet_VERSION
+#define crypto_stream_salsa20_IMPLEMENTATION "crypto_stream/salsa20/tweet"
+#define crypto_verify_PRIMITIVE "16"
+#define crypto_verify crypto_verify_16
+#define crypto_verify_BYTES crypto_verify_16_BYTES
+#define crypto_verify_IMPLEMENTATION crypto_verify_16_IMPLEMENTATION
+#define crypto_verify_VERSION crypto_verify_16_VERSION
+#define crypto_verify_16_tweet_BYTES 16
+extern int crypto_verify_16_tweet(const unsigned char *,const unsigned char *);
+#define crypto_verify_16_tweet_VERSION "-"
+#define crypto_verify_16 crypto_verify_16_tweet
+#define crypto_verify_16_BYTES crypto_verify_16_tweet_BYTES
+#define crypto_verify_16_VERSION crypto_verify_16_tweet_VERSION
+#define crypto_verify_16_IMPLEMENTATION "crypto_verify/16/tweet"
+#define crypto_verify_32_tweet_BYTES 32
+extern int crypto_verify_32_tweet(const unsigned char *,const unsigned char *);
+#define crypto_verify_32_tweet_VERSION "-"
+#define crypto_verify_32 crypto_verify_32_tweet
+#define crypto_verify_32_BYTES crypto_verify_32_tweet_BYTES
+#define crypto_verify_32_VERSION crypto_verify_32_tweet_VERSION
+#define crypto_verify_32_IMPLEMENTATION "crypto_verify/32/tweet"
+#endif


### PR DESCRIPTION
Build Monocypher itself as C++, wrapping it in a namespace.
This moves its `crypto_`-prefixed symbols out of the global
namespace where they can collide with libSodium or OpenSSL.

Note: This required a small change to Monocypher's headers.
I've made the change in a fork, and updated the .gitmodules
file to point to the fork.